### PR TITLE
v1.1.0b(2023.8.27)

### DIFF
--- a/Components/Feed/Feed+Listeners.swift
+++ b/Components/Feed/Feed+Listeners.swift
@@ -41,6 +41,7 @@ extension Feed {
                     default:
                         break
                     }
+                    
                     ModalService.shared.presentModal(GraniteToastView(response.notification))
                 }
             }
@@ -52,7 +53,7 @@ extension Feed {
                 if let error = value as? StandardErrorMeta {
                     ModalService.shared.presentModal(GraniteToastView(error))
                 } else {
-                    LoomLog("🟡 Restarting")
+                    LoomLog("🟡 Restarting Feed")
                     pager.reset()
                 }
             }

--- a/Components/Feed/Feed+View.swift
+++ b/Components/Feed/Feed+View.swift
@@ -29,6 +29,7 @@ extension Feed: GraniteNavigationDestination {
         .graniteNavigationDestinationIf(isCommunity) {
             communityInfoMenuView
         }
+        //What's New Modal
 //        .onAppear {
 //            if content.state.lastVersionUpdateNotice != Device.appVersion {
 //                modal.presentSheet {

--- a/Components/Home/Home+View.swift
+++ b/Components/Home/Home+View.swift
@@ -8,38 +8,28 @@ extension Home: View {
     var safeAreaTop: CGFloat {
         #if os(iOS)
         return .layer1
-        #endif
+        #else
         return 0
-    }
-    
-    var isBottom: Bool {
-        #if os(iOS)
-        if #available(iOS 11.0, *),
-           let keyWindow = UIApplication.shared.keyWindow,
-           keyWindow.safeAreaInsets.bottom > 0 {
-            return true
-        }
         #endif
-        return false
     }
     
     var tabViewHeight: CGFloat {
-        if Device.isExpandedLayout {
-            return 56
-        } else {
+        if Device.hasNotch {
             return 84
+        } else {
+            return 56
         }
     }
     
     var bottomPadding: CGFloat {
-        if isBottom && Device.isExpandedLayout == false {
+        if Device.hasNotch {
             return 20
         } else if Device.isMacOS {
             return 24
         } else if Device.isiPad {
             return 36
         } else {
-            return 10
+            return 0
         }
     }
     

--- a/Components/Reply/Reply+Center.swift
+++ b/Components/Reply/Reply+Center.swift
@@ -5,6 +5,7 @@ extension Reply {
     struct Center: GraniteCenter {
         struct State: GraniteState {
             var content: String = ""
+            var isReplying: Bool = false
         }
         
         @Store public var state: State

--- a/Components/Reply/Reply+View.swift
+++ b/Components/Reply/Reply+View.swift
@@ -6,20 +6,10 @@ import MarkdownView
 extension Reply: View {
     public var view: some View {
         VStack(alignment: .leading, spacing: 0) {
-            switch kind {
-            case .replyPost(let model), .editReplyPost(_, let model):
-                HeaderView(showPostActions: false)
+            if Device.isExpandedLayout || !isPushed {
+                headerView
                     .padding(.horizontal, .layer3)
-                    .padding(.bottom, .layer3)
-                    .contentContext(.init(postModel: model))
-            case .replyComment(let model),
-                    .editReplyComment(let model):
-                HeaderView(showPostActions: false)
-                    .padding(.horizontal, .layer3)
-                    .padding(.bottom, .layer3)
-                    .contentContext(.init(commentModel: model))
-            default:
-                EmptyView()
+                    .padding(.bottom, .layer4)
             }
             
             Divider()
@@ -56,7 +46,6 @@ extension Reply: View {
             .fixedSize(horizontal: false, vertical: true)
             
             Divider()
-                .padding(.bottom, Device.isMacOS ? 0 : .layer4)
             
             WriteView(kind: kind, title: .constant(""),
                       content: _state.content)
@@ -66,31 +55,45 @@ extension Reply: View {
             HStack(spacing: .layer3) {
                 Spacer()
                 
-                Button {
-                    GraniteHaptic.light.invoke()
-                    
-                    switch kind {
-                    case .replyPost(let model):
-                        content.center.interact.send(ContentService.Interact.Meta(kind: .replyPost(model, state.content)))
-                    case .replyComment(let model):
-                        content.center.interact.send(ContentService.Interact.Meta(kind: .replyComment(model, state.content)))
-                    case .editReplyPost(let model, _), .editReplyComment(let model):
-                        content.center.interact.send(ContentService.Interact.Meta(kind: .editCommentSubmit(model, state.content)))
-                    default:
-                        break
+                if state.isReplying {
+                    #if os(macOS)
+                    ProgressView()
+                        .scaleEffect(0.6)
+                    #else
+                    ProgressView()
+                    #endif
+                } else {
+                    Button {
+                        GraniteHaptic.light.invoke()
+                        
+                        _state.isReplying.wrappedValue = true
+                        switch kind {
+                        case .replyPost(let model):
+                            content.center.interact.send(ContentService.Interact.Meta(kind: .replyPost(model, state.content)))
+                        case .replyComment(let model):
+                            content.center.interact.send(ContentService.Interact.Meta(kind: .replyComment(model, state.content)))
+                        case .editReplyPost(let model, _), .editReplyComment(let model):
+                            content.center.interact.send(ContentService.Interact.Meta(kind: .editCommentSubmit(model, state.content)))
+                        default:
+                            break
+                        }
+                    } label: {
+                        Image(systemName: kind.isEditingReply ? "sdcard.fill" : "paperplane.fill")
+                            .font(.headline)
                     }
-                } label: {
-                    Image(systemName: kind.isEditingReply ? "sdcard.fill" : "paperplane.fill")
-                        .font(.headline)
+                    .buttonStyle(PlainButtonStyle())
                 }
-                .buttonStyle(PlainButtonStyle())
                 
                 Spacer()
             }
             .frame(height: 24)
             .padding(.vertical, .layer4)
         }
-        .padding(.top, .layer4)
-        .background(Device.isIPhone ? .clear : Color.background)
+        .padding(.top, isPushed ? 0 : .layer4)
+        .background(Device.isIPhone && !isPushed ? .clear : Color.background)
+        .graniteNavigationDestinationIf(isPushed) {
+            headerView
+                .padding(.leading, .layer4)
+        }
     }
 }

--- a/Components/Reply/Views/Reply.HeaderView.swift
+++ b/Components/Reply/Views/Reply.HeaderView.swift
@@ -1,0 +1,30 @@
+//
+//  Reply.HeaderView.swift
+//  Loom
+//
+//  Created by PEXAVC on 8/26/23.
+//
+
+import Foundation
+import Granite
+import SwiftUI
+import GraniteUI
+import MarkdownView
+
+extension Reply {
+    var headerView: some View {
+        Group {
+            switch kind {
+            case .replyPost(let model), .editReplyPost(_, let model):
+                HeaderView(showPostActions: false)
+                    .contentContext(.init(postModel: model))
+            case .replyComment(let model),
+                    .editReplyComment(let model):
+                HeaderView(showPostActions: false)
+                    .contentContext(.init(commentModel: model))
+            default:
+                EmptyView()
+            }
+        }
+    }
+}

--- a/Components/Search/Search+Listeners.swift
+++ b/Components/Search/Search+Listeners.swift
@@ -1,0 +1,29 @@
+//
+//  Search+Listeners.swift
+//  Loom
+//
+//  Created by PEXAVC on 8/26/23.
+//
+
+import Granite
+import SwiftUI
+import LemmyKit
+
+extension Search {
+    var listeners: Void {
+        config
+            .center
+            .restart
+            .listen(.broadcast("search")) { value in
+                if (value as? StandardErrorMeta) == nil {
+                    LoomLog("🟡 Restarting Search")
+                    
+                    conductor.reset()
+                    
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                        conductor.startTimer("")
+                    }
+                }
+            }
+    }
+}

--- a/Components/Search/Search+View.swift
+++ b/Components/Search/Search+View.swift
@@ -80,14 +80,6 @@ extension Search: View {
                 Spacer()
             }
         }
-//        .graniteNavigation(backgroundColor: Color.background, disable: community == nil || Device.isExpandedLayout) {
-//            Image(systemName: "chevron.backward")
-//                .renderingMode(.template)
-//                .font(.title2)
-//                .frame(width: 24, height: 24)
-//                .contentShape(Rectangle())
-//                .offset(x: -2)
-//        }
         .padding(.top, isModal ? (Device.isExpandedLayout ? .layer3 : .layer2) : ContainerConfig.generalViewTopPadding)
         .foregroundColor(.foreground)
         .background(Color.background)

--- a/Components/Search/Search.swift
+++ b/Components/Search/Search.swift
@@ -5,6 +5,8 @@ import LemmyKit
 struct Search: GraniteComponent {
     @Command var center: Center
     
+    @Relay var config: ConfigService
+    
     @Environment(\.presentationMode) var presentationMode
     
     @StateObject var conductor: SearchConductor = .init()

--- a/Loom.xcodeproj/project.pbxproj
+++ b/Loom.xcodeproj/project.pbxproj
@@ -313,6 +313,12 @@
 		71899E602A89D68E0073158F /* Loom.CollectionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71899E5E2A89D68E0073158F /* Loom.CollectionsView.swift */; };
 		71899E622A89D6A30073158F /* Loom.CreateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71899E612A89D6A30073158F /* Loom.CreateView.swift */; };
 		71899E632A89D6A30073158F /* Loom.CreateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71899E612A89D6A30073158F /* Loom.CreateView.swift */; };
+		7195B4922A9A9C8E0026A6E9 /* ContentContext.Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7195B4912A9A9C8E0026A6E9 /* ContentContext.Helpers.swift */; };
+		7195B4932A9A9C8E0026A6E9 /* ContentContext.Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7195B4912A9A9C8E0026A6E9 /* ContentContext.Helpers.swift */; };
+		7195B4952A9AA5380026A6E9 /* Search+Listeners.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7195B4942A9AA5380026A6E9 /* Search+Listeners.swift */; };
+		7195B4962A9AA5380026A6E9 /* Search+Listeners.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7195B4942A9AA5380026A6E9 /* Search+Listeners.swift */; };
+		7195B4992A9AD4E40026A6E9 /* Reply.HeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7195B4982A9AD4E40026A6E9 /* Reply.HeaderView.swift */; };
+		7195B49A2A9AD4E40026A6E9 /* Reply.HeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7195B4982A9AD4E40026A6E9 /* Reply.HeaderView.swift */; };
 		7197FB032964B4C0005EBBA4 /* GraniteModalManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7197FAF02964B4BF005EBBA4 /* GraniteModalManager.swift */; };
 		7197FB042964B4C0005EBBA4 /* GraniteModalManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7197FAF02964B4BF005EBBA4 /* GraniteModalManager.swift */; };
 		7197FB052964B4C0005EBBA4 /* GraniteModal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7197FAF12964B4BF005EBBA4 /* GraniteModal.swift */; };
@@ -843,6 +849,9 @@
 		71899E5B2A89D66D0073158F /* Loom.SymbolView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Loom.SymbolView.swift; sourceTree = "<group>"; };
 		71899E5E2A89D68E0073158F /* Loom.CollectionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Loom.CollectionsView.swift; sourceTree = "<group>"; };
 		71899E612A89D6A30073158F /* Loom.CreateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Loom.CreateView.swift; sourceTree = "<group>"; };
+		7195B4912A9A9C8E0026A6E9 /* ContentContext.Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentContext.Helpers.swift; sourceTree = "<group>"; };
+		7195B4942A9AA5380026A6E9 /* Search+Listeners.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Search+Listeners.swift"; sourceTree = "<group>"; };
+		7195B4982A9AD4E40026A6E9 /* Reply.HeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reply.HeaderView.swift; sourceTree = "<group>"; };
 		719725FD28CC864400A64334 /* Loom--iOS--Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Loom--iOS--Info.plist"; sourceTree = "<group>"; };
 		7197FAF02964B4BF005EBBA4 /* GraniteModalManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GraniteModalManager.swift; sourceTree = "<group>"; };
 		7197FAF12964B4BF005EBBA4 /* GraniteModal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GraniteModal.swift; sourceTree = "<group>"; };
@@ -1526,7 +1535,6 @@
 				71622E922A6E4103006233F3 /* View+OnSwipe.swift */,
 				715826812A889506000E4B49 /* View+Readability.swift */,
 				710540712A91427100B9DC8A /* View+Size.swift */,
-				71258D262A55F951007E52FC /* Device.swift */,
 				71622E8C2A6E0A26006233F3 /* Image.swift */,
 				71EB91BC2A8028400091EE5B /* Numbers.swift */,
 				71A4A12E2A63326400689DF2 /* URL+Host.swift */,
@@ -1581,6 +1589,7 @@
 			children = (
 				715151252A8F720300251978 /* ContentContext.swift */,
 				715151282A8F79A200251978 /* ContentContext.Display.swift */,
+				7195B4912A9A9C8E0026A6E9 /* ContentContext.Helpers.swift */,
 			);
 			path = Context;
 			sourceTree = "<group>";
@@ -1614,6 +1623,7 @@
 		71622E982A6E5796006233F3 /* Reply */ = {
 			isa = PBXGroup;
 			children = (
+				7195B4972A9AD4D10026A6E9 /* Views */,
 				71622E992A6E5796006233F3 /* Reply+Center.swift */,
 				71622E9B2A6E5796006233F3 /* Reply+View.swift */,
 				71622E9A2A6E5796006233F3 /* Reply.swift */,
@@ -1624,17 +1634,17 @@
 		7166E9D72A74A28D004F88D7 /* LAExtensions */ = {
 			isa = PBXGroup;
 			children = (
+				714B487D2A8188DA00AC6199 /* ResourceContext.swift */,
+				714B487A2A81847800AC6199 /* ResourceType.swift */,
+				710BEAA72A86E89E0075A141 /* ListingType.swift */,
+				7166E9DE2A74A2C6004F88D7 /* Community.swift */,
+				714B48802A81A5D600AC6199 /* Locateable.swift */,
+				7166E9E12A74A2CE004F88D7 /* Comment.swift */,
+				710BEAA42A86E87B0075A141 /* SortType.swift */,
+				7166E9EA2A751441004F88D7 /* UserInfo.swift */,
+				713129BA2A83280A00C6B31D /* Instance.swift */,
 				7166E9D82A74A2B2004F88D7 /* Person.swift */,
 				7166E9DB2A74A2BC004F88D7 /* Post.swift */,
-				7166E9DE2A74A2C6004F88D7 /* Community.swift */,
-				7166E9EA2A751441004F88D7 /* UserInfo.swift */,
-				7166E9E12A74A2CE004F88D7 /* Comment.swift */,
-				713129BA2A83280A00C6B31D /* Instance.swift */,
-				714B487A2A81847800AC6199 /* ResourceType.swift */,
-				714B48802A81A5D600AC6199 /* Locateable.swift */,
-				714B487D2A8188DA00AC6199 /* ResourceContext.swift */,
-				710BEAA42A86E87B0075A141 /* SortType.swift */,
-				710BEAA72A86E89E0075A141 /* ListingType.swift */,
 			);
 			path = LAExtensions;
 			sourceTree = "<group>";
@@ -1688,6 +1698,7 @@
 				71A28E18295237AE00EAE8EE /* Passthrough.swift */,
 				71BE94DD2A954DCE004A3AC3 /* Compressor.swift */,
 				71AF14662A2E807300EEBD4B /* Disclaimer.swift */,
+				71258D262A55F951007E52FC /* Device.swift */,
 				714B48772A816CF900AC6199 /* Logger.swift */,
 				71E5F3CA2A73A02500299558 /* Haptic.swift */,
 				71A28E1E295237AE00EAE8EE /* Run.swift */,
@@ -1756,6 +1767,14 @@
 			path = Header;
 			sourceTree = "<group>";
 		};
+		7195B4972A9AD4D10026A6E9 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				7195B4982A9AD4E40026A6E9 /* Reply.HeaderView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
 		719725F628CC7F0300A64334 /* Views */ = {
 			isa = PBXGroup;
 			children = (
@@ -1767,18 +1786,18 @@
 				71C5FF612A64688A00F99A84 /* Drawer */,
 				710283312A2A54C300010877 /* Sliders */,
 				712BEB5829074CFB00D257B7 /* Camera */,
-				717C129E293BEF730060A446 /* AppBlurBackground.swift */,
-				714FA06129FF11E1002E4A7C /* InfoIconView.swift */,
-				71E5F3C12A73244500299558 /* LazyScrollView.swift */,
 				71B21B802A6C791E005B3BFB /* GraniteStandardModalView.swift */,
-				716157D82A85C29500449EE4 /* WebView.swift */,
-				716CCAD12A8ACCC2009F9413 /* StandardToolbarView.swift */,
-				711849482A8EC5D5000F5A67 /* LogoView.swift */,
-				71622E8F2A6E3DED006233F3 /* AdaptsToKeyboard.swift */,
 				71BE94F52A958EC2004A3AC3 /* KeyboardToolbarTextView.swift */,
+				716CCAD12A8ACCC2009F9413 /* StandardToolbarView.swift */,
+				717C129E293BEF730060A446 /* AppBlurBackground.swift */,
+				71622E8F2A6E3DED006233F3 /* AdaptsToKeyboard.swift */,
 				71BE94FC2A95DF74004A3AC3 /* GenericPreview.swift */,
+				71E5F3C12A73244500299558 /* LazyScrollView.swift */,
+				714FA06129FF11E1002E4A7C /* InfoIconView.swift */,
 				710540F52A920E8200B9DC8A /* ShareModal.swift */,
 				7151511E2A8F6D0B00251978 /* SideMenu.swift */,
+				711849482A8EC5D5000F5A67 /* LogoView.swift */,
+				716157D82A85C29500449EE4 /* WebView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -1975,6 +1994,7 @@
 			isa = PBXGroup;
 			children = (
 				71C69E462A70556F00B54AD6 /* Views */,
+				7195B4942A9AA5380026A6E9 /* Search+Listeners.swift */,
 				71C69E1E2A70469900B54AD6 /* Search+Center.swift */,
 				71C69E1F2A70469900B54AD6 /* Search+View.swift */,
 				71C69E212A70469900B54AD6 /* Search.swift */,
@@ -2079,23 +2099,23 @@
 		71C9F9102A60BCFF0089D7EA /* LAViews */ = {
 			isa = PBXGroup;
 			children = (
-				715826772A881DD8000E4B49 /* ViewingContext.swift */,
-				71E5209F2A9357820057EA83 /* CardStyle.swift */,
-				71F778C42A71ABAC00C9C5C4 /* CensorView.swift */,
-				7166E9D12A747ED7004F88D7 /* ReportView.swift */,
-				71F778C72A71AE0300C9C5C4 /* FeedStyle.swift */,
+				71E5F3C92A739E7800299558 /* Community */,
+				71E5F3C62A739E3D00299558 /* Comments */,
+				711D39272A8413E100CF2DB2 /* Instances */,
+				71E5F3C72A739E5200299558 /* Headers */,
+				71E5F3C82A739E6100299558 /* Footers */,
+				71FF4D612A93F380005BF579 /* Modals */,
+				71E5F3C42A739E1900299558 /* Posts */,
+				71E5F3C52A739E3000299558 /* User */,
 				71C8BE772A7F2E1E008694C7 /* ContentMetadataView.swift */,
 				7166E9E42A74EE64004F88D7 /* BlockedPickerView.swift */,
 				7166E9E72A7503A0004F88D7 /* CardActionsView.swift */,
+				715826772A881DD8000E4B49 /* ViewingContext.swift */,
+				71F778C42A71ABAC00C9C5C4 /* CensorView.swift */,
+				7166E9D12A747ED7004F88D7 /* ReportView.swift */,
 				71B7A1DB2A68E5CA003E6D4D /* LoginView.swift */,
-				71E5F3C52A739E3000299558 /* User */,
-				71E5F3C42A739E1900299558 /* Posts */,
-				71FF4D612A93F380005BF579 /* Modals */,
-				71E5F3C82A739E6100299558 /* Footers */,
-				71E5F3C72A739E5200299558 /* Headers */,
-				711D39272A8413E100CF2DB2 /* Instances */,
-				71E5F3C62A739E3D00299558 /* Comments */,
-				71E5F3C92A739E7800299558 /* Community */,
+				71F778C72A71AE0300C9C5C4 /* FeedStyle.swift */,
+				71E5209F2A9357820057EA83 /* CardStyle.swift */,
 			);
 			path = LAViews;
 			sourceTree = "<group>";
@@ -2643,6 +2663,7 @@
 				71BE94FD2A95DF74004A3AC3 /* GenericPreview.swift in Sources */,
 				71A28E23295237AE00EAE8EE /* TapAndLongPressModifier.swift in Sources */,
 				71622E902A6E3DED006233F3 /* AdaptsToKeyboard.swift in Sources */,
+				7195B4952A9AA5380026A6E9 /* Search+Listeners.swift in Sources */,
 				7102838B2A2A54C300010877 /* EnvironmentValues+RangeSliderStyle.swift in Sources */,
 				71C5FF6B2A64688B00F99A84 /* Drawer+Computed.swift in Sources */,
 				7151512F2A8FBE0D00251978 /* GraniteScrollView+macOS.swift in Sources */,
@@ -2677,6 +2698,7 @@
 				712C0D7D2A7CA32500DBDCC9 /* CGPoint.swift in Sources */,
 				71B7A1F12A691470003E6D4D /* ShinyView.swift in Sources */,
 				7151512C2A8FB12F00251978 /* Profile+Listeners.swift in Sources */,
+				7195B4922A9A9C8E0026A6E9 /* ContentContext.Helpers.swift in Sources */,
 				717090A92A7ED7DC009F1FB7 /* MD5.swift in Sources */,
 				710283972A2A54C300010877 /* AnyPointSliderStyle.swift in Sources */,
 				710283832A2A54C300010877 /* RangeSlider.swift in Sources */,
@@ -2884,6 +2906,7 @@
 				711D39252A840AED00CF2DB2 /* SearchConductor.BasicKeys.swift in Sources */,
 				71A28E0A295233B200EAE8EE /* Fonts.swift in Sources */,
 				717090AD2A7ED7DC009F1FB7 /* NSTimeInterval+Util.swift in Sources */,
+				7195B4992A9AD4E40026A6E9 /* Reply.HeaderView.swift in Sources */,
 				71B21B812A6C791E005B3BFB /* GraniteStandardModalView.swift in Sources */,
 				71EAF47B2A7DA3320034FCB9 /* ExplorerService.swift in Sources */,
 				71FF4D632A93F394005BF579 /* Modals.swift in Sources */,
@@ -3026,6 +3049,7 @@
 				7166E9E02A74A2C6004F88D7 /* Community.swift in Sources */,
 				71C9F8D52A60B7C10089D7EA /* Feed+View.swift in Sources */,
 				71A28D9B295231E600EAE8EE /* Array.swift in Sources */,
+				7195B49A2A9AD4E40026A6E9 /* Reply.HeaderView.swift in Sources */,
 				71F778B32A719C6A00C9C5C4 /* HeaderCardView.swift in Sources */,
 				71EB91CA2A8054520091EE5B /* LocalCommunityPickerView.swift in Sources */,
 				710283BC2A2A54C300010877 /* HorizontalValueTrack.swift in Sources */,
@@ -3138,6 +3162,7 @@
 				71C9F9342A610C110089D7EA /* FooterView.swift in Sources */,
 				711D39302A84A96200CF2DB2 /* DebugComponent.swift in Sources */,
 				71899E372A89528C0073158F /* LoomService+Center.swift in Sources */,
+				7195B4962A9AA5380026A6E9 /* Search+Listeners.swift in Sources */,
 				71A4A1222A61C41000689DF2 /* AccountService+Center.swift in Sources */,
 				710283822A2A54C300010877 /* EnvironmentValues+TrackPoint.swift in Sources */,
 				710283862A2A54C300010877 /* RangeSliderStyle.swift in Sources */,
@@ -3163,6 +3188,7 @@
 				71899E582A89A0D80073158F /* Feed+Listeners.swift in Sources */,
 				717090AE2A7ED7DC009F1FB7 /* NSTimeInterval+Util.swift in Sources */,
 				71F0420D2A69D39600788CDC /* ContentService.Interact.swift in Sources */,
+				7195B4932A9A9C8E0026A6E9 /* ContentContext.Helpers.swift in Sources */,
 				711D392A2A8413EF00CF2DB2 /* InstanceCardView.swift in Sources */,
 				713129BC2A83280A00C6B31D /* Instance.swift in Sources */,
 				711B3F9B2885D43B00F3080D /* PEXApp.swift in Sources */,
@@ -3445,7 +3471,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2023.8.26;
+				CURRENT_PROJECT_VERSION = 2023.8.27;
 				DEVELOPMENT_TEAM = CV8LAA8JAP;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -3480,7 +3506,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2023.8.26;
+				CURRENT_PROJECT_VERSION = 2023.8.27;
 				DEVELOPMENT_TEAM = CV8LAA8JAP;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -3518,7 +3544,7 @@
 				CODE_SIGN_ENTITLEMENTS = macOS/macOS.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 2023.8.27;
 				DEVELOPMENT_TEAM = CV8LAA8JAP;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
@@ -3548,7 +3574,7 @@
 				CODE_SIGN_ENTITLEMENTS = macOS/macOS.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 2023.8.27;
 				DEVELOPMENT_TEAM = CV8LAA8JAP;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;

--- a/Loom.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Loom.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,7 +15,7 @@
       "location" : "https://github.com/pexavc/Granite.git",
       "state" : {
         "branch" : "main",
-        "revision" : "b6d1df845ed92ecca6286250efd85a6e61f0e9d9"
+        "revision" : "d8cb80e822b349aceb71650e3ac5b4d483004ea6"
       }
     },
     {

--- a/Services/ContentService/Reducers/ContentService.Interact.swift
+++ b/Services/ContentService/Reducers/ContentService.Interact.swift
@@ -26,6 +26,7 @@ extension ContentService {
             case replyPost(PostView, String)
             case replyPostSubmit(Comment, PostView)
             case replyComment(CommentView, String)
+            //Target, Reply
             case replyCommentSubmit(CommentView, CommentView)
             case editComment(CommentView, PostView?)
             case editCommentSubmit(CommentView, String)
@@ -148,7 +149,11 @@ extension ContentService {
 
                 guard let result else { return }
                 
-                broadcast.send(ResponseMeta(notification: .init(title: "MISC_SUCCESS", message: "ALERT_REPLY_COMMENT_SUCCESS \("@"+model.person.name)", event: .success), kind: .replyCommentSubmit(result.asView(with: model), model)))
+                guard let user = LemmyKit.current.user?.local_user_view.person else {
+                    return
+                }
+                
+                broadcast.send(ResponseMeta(notification: .init(title: "MISC_SUCCESS", message: "ALERT_REPLY_COMMENT_SUCCESS \("@"+model.person.name)", event: .success), kind: .replyCommentSubmit(result.asView(with: model), result.asView(creator: user, post: model.post, community: model.community))))
             case .savePost(let model):
                 _ = await Lemmy.savePost(model.post, save: true)
             case .unsavePost(let model):

--- a/Services/ModalService/ModalService+Actions.swift
+++ b/Services/ModalService/ModalService+Actions.swift
@@ -85,7 +85,7 @@ extension ModalService {
     
     @MainActor
     static func presentSheet<Content : View>(id: String = GraniteSheetManager.defaultId,
-                                             detents: [Detent] = [.small, .medium, .large],
+                                             detents: [Detent] = [.medium, .large],
                                              style : GraniteSheetPresentationStyle = .sheet,
                                              @ViewBuilder content : () -> Content) {
         

--- a/Services/ModalService/Views/Sheet/GraniteSheetContainerView.swift
+++ b/Services/ModalService/Views/Sheet/GraniteSheetContainerView.swift
@@ -6,7 +6,8 @@ import GraniteUI
 public enum Detent: Hashable, CaseIterable {
     case large
     case medium
-    case small
+    //case small
+    case inactive
     
     var height: CGFloat {
         switch self {
@@ -17,9 +18,11 @@ public enum Detent: Hashable, CaseIterable {
             return UIScreen.main.bounds.height - 100
             #endif
         case .medium:
-            return 480
-        case .small:
             return 360
+//        case .small:
+//            return 360
+        case .inactive:
+            return 100
         }
     }
 }
@@ -29,9 +32,6 @@ struct GraniteSheetContainerView<Content : View, Background : View> : View {
     
     @EnvironmentObject var manager : GraniteSheetManager
     
-    #if os(iOS)
-    @State var isSheetExpanded: Bool = false
-    #endif
     
     
     let id: String
@@ -208,12 +208,13 @@ private struct FullScreenCoverBackgroundRemovalView: NSViewRepresentable {
 
 fileprivate extension View {
     func showDrawer<Content: View>(_ condition: Binding<Bool>,
-                                   _ detents: [Detent] = [.small],
+                                   _ detents: [Detent] = [.medium],
                     @ViewBuilder _ content: () -> Content) -> some View {
-        self.overlayIf(condition.wrappedValue, alignment: .top) {
+
+        return self.overlayIf(condition.wrappedValue, alignment: .top) {
             Group {
                 #if os(iOS)
-                Drawer(startingHeight: detents.first?.height ?? Detent.small.height) {
+                Drawer(startingHeight: detents.first?.height ?? Detent.medium.height, keyboardAware: true) {
                     ZStack(alignment: .top) {
                         RoundedRectangle(cornerRadius: 12)
                             .foregroundColor(Color.alternateSecondaryBackground)

--- a/Services/ModalService/Views/Sheet/GraniteSheetManager.swift
+++ b/Services/ModalService/Views/Sheet/GraniteSheetManager.swift
@@ -41,12 +41,12 @@ final public class GraniteSheetManager : ObservableObject {
     
     @MainActor
     public func present<Content : View>(id: String = GraniteSheetManager.defaultId,
-                                        detents: [Detent] = [.small, .medium, .large],
+                                        detents: [Detent] = [.medium, .large],
                                         @ViewBuilder content : () -> Content, style : GraniteSheetPresentationStyle = .sheet) {
         self.style = style
         self.detentsMap[id] = detents
         
-        if Device.isiPad {
+        if Device.isIPhone == false {
             self.models[id] = .init(id: id,
                                     content: AnyView(content()
                                         .graniteNavigation(backgroundColor: Color.clear)))

--- a/Shared/Design/Fonts/Fonts.swift
+++ b/Shared/Design/Fonts/Fonts.swift
@@ -106,7 +106,10 @@ extension Font {
         case .title2:
             return .title3
         case .title3:
-            return .headline
+            //headline's weight is bold
+            return .body//.headline
+        case .body:
+            return .subheadline
         case .headline:
             return .subheadline
         case .subheadline:

--- a/Shared/Extensions/View+Navigation.swift
+++ b/Shared/Extensions/View+Navigation.swift
@@ -2,7 +2,7 @@
 //  View+Navigation.swift
 //  Loom
 //
-//  Created by Ritesh Pakala on 8/22/23.
+//  Created by PEXAVC on 8/22/23.
 //
 
 import Foundation

--- a/Shared/LAExtensions/Comment.swift
+++ b/Shared/LAExtensions/Comment.swift
@@ -28,6 +28,33 @@ extension CommentView: Pageable {
     }
 }
 
+extension CommentView: Locateable {
+    var isBaseResource: Bool {
+        LemmyKit.host == community.actor_id.host
+    }
+    
+    var isPeerResource: Bool {
+        community.actor_id.host != creator.actor_id.host
+    }
+}
+
+//TODO: reusable with PostView
+extension CommentView {
+    var viewableHosts: [String] {
+        var hosts: [String] = [LemmyKit.host]
+        
+        if isBaseResource == false {
+            hosts += [community.actor_id.host]
+        }
+        
+        if isPeerResource {
+            hosts += [creator.actor_id.host]
+        }
+        
+        return hosts
+    }
+}
+
 extension CommentView {
     func updateBlock(_ blocked: Bool, personView: PersonView) -> CommentView {
         .init(comment: self.comment, creator: personView.person, post: self.post, community: self.community, counts: self.counts, creator_banned_from_community: self.creator_banned_from_community, subscribed: self.subscribed, saved: self.saved, creator_blocked: blocked)
@@ -73,6 +100,22 @@ extension CommentReplyView {
 extension Comment {
     func asView(creator: Person, postView: PostView) -> CommentView {
         .init(comment: self, creator: creator, post: postView.post, community: postView.community, counts: .new(commentId: self.id, published: self.published), creator_banned_from_community: postView.creator_banned_from_community, subscribed: postView.subscribed, saved: false, creator_blocked: false)
+    }
+    
+    func asView(creator: Person,
+                post: Post,
+                community: Community) -> CommentView {
+        .init(comment: self,
+              creator: creator,
+              post: post,
+              community: community,
+              counts: .new(commentId: self.id, published: self.published),
+              //Thiss can be inconsistent, but since its from replies its highly unlikely
+              creator_banned_from_community: false,
+              //This can be inconsistent
+              subscribed: .notSubscribed,
+              saved: false,
+              creator_blocked: false)
     }
     
     func asView(with model: CommentView) -> CommentView {

--- a/Shared/LAExtensions/Community.swift
+++ b/Shared/LAExtensions/Community.swift
@@ -46,7 +46,7 @@ extension Community {
 
 extension CommunityAggregates {
     static var mock: CommunityAggregates {
-        .init(id: 0, community_id: 0, subscribers: 0, posts: 0, comments: 0, published: "", users_active_day: 0, users_active_week: 0, users_active_month: 0, users_active_half_year: 0, hot_rank: 0)
+        .init(id: 0, community_id: 0, subscribers: 0, posts: 0, comments: 0, published: Date.today.asString, users_active_day: 0, users_active_week: 0, users_active_month: 0, users_active_half_year: 0, hot_rank: 0)
     }
 }
 

--- a/Shared/LAExtensions/Post.swift
+++ b/Shared/LAExtensions/Post.swift
@@ -39,6 +39,22 @@ extension PostView: Locateable {
 }
 
 extension PostView {
+    var viewableHosts: [String] {
+        var hosts: [String] = [LemmyKit.host]
+        
+        if isBaseResource == false {
+            hosts += [community.actor_id.host]
+        }
+        
+        if isPeerResource {
+            hosts += [creator.actor_id.host]
+        }
+        
+        return hosts
+    }
+}
+
+extension PostView {
     func updateBlock(_ blocked: Bool, personView: PersonView) -> PostView {
         .init(post: self.post, creator: personView.person, community: self.community, creator_banned_from_community: self.creator_banned_from_community, counts: self.counts, subscribed: self.subscribed, saved: self.saved, read: self.read, creator_blocked: blocked, unread_comments: self.unread_comments)
     }

--- a/Shared/LAViews/Comments/ThreadView.swift
+++ b/Shared/LAViews/Comments/ThreadView.swift
@@ -10,6 +10,7 @@ struct ThreadView: View {
     @Environment(\.contentContext) var context
     @Environment(\.colorScheme) var colorScheme
     @Environment(\.graniteEvent) var interact
+    @Environment(\.graniteRouter) var router
     
     @GraniteAction<Void> var closeDrawer
     @GraniteAction<CommentView> var showDrawer
@@ -33,6 +34,12 @@ struct ThreadView: View {
         breadCrumbs.last ?? (updatedParentModel ?? context.commentModel)
     }
     
+    @State var threadLocation: FetchType = .base
+    @State var selectedHost: String = LemmyKit.host
+    var viewableHosts: [String] {
+        context.viewbaleHosts
+    }
+    
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             if isModal {
@@ -49,6 +56,10 @@ struct ThreadView: View {
                     .padding(.bottom, .layer4)
                 
                 Divider()
+                
+                sortMenuView
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.layer4)
             }
             
             PagerScrollView(CommentView.self,
@@ -59,9 +70,12 @@ struct ThreadView: View {
                     .attach({ model in
                         if isModal {
                             breadCrumbs.append(model)
-                            pager.fetch()
+                            pager.reset()
                         } else {
-                            showDrawer.perform(model)
+                            ModalService
+                                .shared
+                                .showThreadDrawer(commentView: model,
+                                                  context: context)
                         }
                     }, at: \.showDrawer)
                     .contentContext(.addCommentModel(model: commentView, context))
@@ -70,19 +84,21 @@ struct ThreadView: View {
             .environmentObject(pager)
             .background(Color.alternateBackground)
         }
-        .background(Color.background)
+        .background(isModal ? .clear : Color.background)
         .padding(.top, (Device.isMacOS || !isModal) ? 0 : .layer3)
         .task {
+            self.threadLocation = context.location
+            
             pager.hook { page in
                 let comments = await Lemmy
-                    .comments(context.commentModel?.post,
-                              comment: context.commentModel?.comment,
+                    .comments(currentModel?.post,
+                              comment: currentModel?.comment,
                               community: context.community?.lemmy,
                               page: page,
                               type: .all,
-                              location: context.location)
+                              location: threadLocation)
                 
-                return comments.filter { $0.id != context.commentModel?.id }
+                return comments.filter { $0.id != currentModel?.id }
             }.fetch()
         }
     }
@@ -116,7 +132,36 @@ extension ThreadView {
             #endif
             
             FooterView(isHeader: true,
-                       showScores: config.state.showScores)
+                       showScores: config.state.showScores,
+                       isComposable: true)
+            .attach({ model in
+                router.push(style: .customTrailing(Color.background)) {
+                    Reply(kind: .replyComment(model), isPushed: true)
+                        .attach({ (updatedModel, replyModel) in
+                            ModalService.shared.presentModal(GraniteToastView(StandardNotificationMeta(title: "MISC_SUCCESS", message: "ALERT_REPLY_COMMENT_SUCCESS \("@"+model.creator.name)", event: .success)))
+                            
+                            DispatchQueue.main.async {
+                                self.updatedParentModel = (updatedParentModel ?? model)?.incrementReplyCount()
+                                
+                                self.pager.insert(model)
+                                
+                                self.router.pop()
+                            }
+                        }, at: \.updateComment)
+                }
+//                ModalService
+//                    .shared
+//                    .showReplyCommentModal(isEditing: false,
+//                                           model: model) { (updatedModel, replyModel) in
+//
+//                    DispatchQueue.main.async {
+//                        self.updatedParentModel = (updatedParentModel ?? model)?.incrementReplyCount()
+//
+//                        guard let replyModel else { return }
+//                        pager.insert(replyModel)
+//                    }
+//                }
+            }, at: \.replyComment)
         }
         .fixedSize(horizontal: false, vertical: true)
     }
@@ -124,10 +169,56 @@ extension ThreadView {
     var contentBody: some View {
         VStack(spacing: 0) {
             ScrollView {
-                MarkdownView(text: context.commentModel?.comment.content ?? "")
+                MarkdownView(text: currentModel?.comment.content ?? "")
                     .fontGroup(PostDisplayFontGroup())
                     .markdownViewRole(.editor)
             }
         }
+    }
+}
+
+extension ThreadView {
+    var sortMenuView: some View {
+        HStack(spacing: .layer4) {
+            Menu {
+                ForEach(0..<viewableHosts.count) { index in
+                    let isSource: Bool = index == 1 && currentModel?.isBaseResource == false
+                    let isPeer: Bool = !isSource && index > 0
+                    let imageName: String = isSource ? "globe.americas" : (isPeer ? "person.wave.2" : "house")
+                    Button {
+                        GraniteHaptic.light.invoke()
+                        
+                        if isSource {
+                            self.threadLocation = .source
+                        } else if index > 0 {
+                            if currentModel?.isPeerResource == true {
+                                self.threadLocation = .peer(viewableHosts[index])
+                            } else if context.viewingContext.isBookmark {
+                                self.threadLocation = context.viewingContext.bookmarkLocation
+                            }
+                        } else {
+                            self.threadLocation = .base
+                        }
+                        self.selectedHost = viewableHosts[index]
+                        
+                        pager.fetch(force: true)
+                    } label: {
+                        Text(viewableHosts[index])
+                        Image(systemName: imageName)
+                    }
+                }
+            } label: {
+                Text(selectedHost)
+#if os(iOS)
+                Image(systemName: "chevron.up.chevron.down")
+#endif
+            }
+            .menuStyle(BorderlessButtonMenuStyle())
+            .frame(maxWidth: Device.isMacOS ? 100 : nil)
+            
+            Spacer()
+        }
+        .foregroundColor(Device.isMacOS ? .foreground : .accentColor)
+        .offset(x: (Device.isExpandedLayout) ? -2 : 0, y: 0)
     }
 }

--- a/Shared/LAViews/Headers/HeaderCardView.swift
+++ b/Shared/LAViews/Headers/HeaderCardView.swift
@@ -22,6 +22,8 @@ struct HeaderCardView: View {
     @GraniteAction<Int> var tappedDetail
     @GraniteAction<Int> var tappedCrumb
     @GraniteAction<Void> var edit
+    @GraniteAction<Void> var goToThread
+    @GraniteAction<Void> var replyToContent
     
     @State var postView: PostView? = nil
     
@@ -100,6 +102,12 @@ struct HeaderCardView: View {
                             self.fetchPostView()
                         }, at: \.goToPost)
                         .attach({
+                            goToThread.perform()
+                        }, at: \.goToThread)
+                        .attach({
+                            replyToContent.perform()
+                        }, at: \.replyToContent)
+                        .attach({
                             edit.perform()
                         }, at: \.edit)
                 }
@@ -135,8 +143,9 @@ struct HeaderCardView: View {
             self.layout._state.feedContext.wrappedValue = .viewPost(postView)
         } else {
             
-            router.push {
-                PostDisplayView(context: _context)
+            router.push(style: .customTrailing()) {
+                PostDisplayView(isPushed: true)
+                    .contentContext(.withPostModel(postView, context))
             }
             
             self.postView = postView

--- a/Shared/LAViews/Headers/HeaderView.swift
+++ b/Shared/LAViews/Headers/HeaderView.swift
@@ -218,8 +218,9 @@ struct HeaderView: View {
         } else {
             self.postView = postView
             
-            router.push {
-                PostDisplayView(context: _context)
+            router.push(style: .customTrailing(Color.background)) {
+                PostDisplayView(isPushed: true)
+                    .contentContext(.withPostModel(postView, context))
             }
         }
     }

--- a/Shared/LAViews/Modals/Modals.swift
+++ b/Shared/LAViews/Modals/Modals.swift
@@ -86,9 +86,9 @@ extension ModalService {
         
         presentSheet {
             Reply(kind: replyKind)
-                .attach({ model in
+                .attach({ (updatedModel, replyModel) in
                     DispatchQueue.main.async {
-                        update?(model)
+                        update?(updatedModel)
                         
                         self.dismissSheet()
                     }
@@ -124,15 +124,15 @@ extension ModalService {
     @MainActor
     func showReplyCommentModal(isEditing: Bool,
                                model: CommentView?,
-                               _ update: ((CommentView) -> Void)? = nil) {
+                               _ update: ((CommentView, CommentView?) -> Void)? = nil) {
         guard let model else {
             return
         }
         
         presentSheet {
             Reply(kind: isEditing ? .editReplyComment(model) : .replyComment(model))
-                .attach({ replyModel in
-                    update?(replyModel)
+                .attach({ (updatedModel, replyModel) in
+                    update?(updatedModel, replyModel)
                     
                     if isEditing {
                         //TODO: edit success modal

--- a/Shared/LAViews/Posts/PostActionsView.swift
+++ b/Shared/LAViews/Posts/PostActionsView.swift
@@ -14,7 +14,9 @@ import LemmyKit
 struct PostActionsView: View {
     @GraniteAction<Community> var viewCommunity
     @GraniteAction<Void> var goToPost
+    @GraniteAction<Void> var goToThread
     @GraniteAction<Void> var edit
+    @GraniteAction<Void> var replyToContent
     
     @GraniteAction<ContentInteraction.Kind> var interact
     //A view needs updating outside of this view's potential hierarchy
@@ -43,44 +45,35 @@ struct PostActionsView: View {
     
     var body: some View {
         Menu {
-            if let name = community?.name {
-                Button {
-                    GraniteHaptic.light.invoke()
-                    
-                    let community: Community? = community ?? postView?.community
-                    
-                    guard let community else { return }
-                    
-                    if Device.isExpandedLayout {
-                        
-                        viewCommunity.perform(community)
-                    } else {
-                        router.push {
-                            Feed(community)
-                        }
-                    }
-                } label: {
-                    Text("!\(name)")
-                    Image(systemName: "arrow.right.circle")
-                }
-                .buttonStyle(PlainButtonStyle())
-            }
-            
-            if shouldRouteToPost {
-                Button {
-                    GraniteHaptic.light.invoke()
-                    goToPost.perform()
-                } label: {
-                    Text("POST_ACTIONS_GO_TO_POST")
-                    Image(systemName: "arrow.right.circle")
-                }
-                .buttonStyle(PlainButtonStyle())
-            }
+            navigationActions
             
             if community != nil || postView != nil {
                 Divider()
             }
             
+            interactionActions
+            
+            Divider()
+            
+            destructiveActions
+                
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(Device.isExpandedLayout ? .subheadline : .footnote.bold())
+                .frame(width: Device.isMacOS ? 16 : 24, height: isCompact ? 12 : 24)
+                .contentShape(Rectangle())
+                .foregroundColor(.foreground)
+                .offset(x: Device.isMacOS ? 8 : 0)
+        }
+        .menuStyle(BorderlessButtonMenuStyle())
+        .menuIndicator(.hidden)
+        .frame(width: Device.isMacOS ? 20 : 24, height: 12)
+    }
+}
+
+extension PostActionsView {
+    var interactionActions: some View {
+        Group {
             if person?.isMe == false,
                let bookmarkKind {
                 Button {
@@ -126,21 +119,84 @@ struct PostActionsView: View {
             .buttonStyle(PlainButtonStyle())
             #endif
             
+            Divider()
             if person?.isMe == true {
-                Divider()
                 
                 Button {
                     GraniteHaptic.light.invoke()
                     edit.perform()
                 } label: {
                     Text("MISC_EDIT")
-                    Image(systemName: "square.and.pencil")
+                    Image(systemName: "pencil.and.outline")
                 }
                 .buttonStyle(PlainButtonStyle())
             }
             
-            Divider()
+            if context.isPreview == false {
+                Button {
+                    GraniteHaptic.light.invoke()
+                    replyToContent.perform()
+                } label: {
+                    //TODO: localize
+                    Text("Reply")
+                    Image(systemName: "square.and.pencil")
+                }
+                .buttonStyle(PlainButtonStyle())
+            }
+        }
+    }
+    var navigationActions: some View {
+        Group {
+            if let name = community?.name {
+                Button {
+                    GraniteHaptic.light.invoke()
+                    
+                    let community: Community? = community ?? postView?.community
+                    
+                    guard let community else { return }
+                    
+                    if Device.isExpandedLayout {
+                        
+                        viewCommunity.perform(community)
+                    } else {
+                        router.push {
+                            Feed(community)
+                        }
+                    }
+                } label: {
+                    Text("!\(name)")
+                    Image(systemName: "arrow.right.circle")
+                }
+                .buttonStyle(PlainButtonStyle())
+            }
             
+            if shouldRouteToPost {
+                Button {
+                    GraniteHaptic.light.invoke()
+                    goToPost.perform()
+                } label: {
+                    Text("POST_ACTIONS_GO_TO_POST")
+                    Image(systemName: "arrow.right.circle")
+                }
+                .buttonStyle(PlainButtonStyle())
+            }
+            
+            if context.isComment {
+                Button {
+                    GraniteHaptic.light.invoke()
+                    goToThread.perform()
+                } label: {
+                    //TODO: localize
+                    Text("Go to thread")
+                    Image(systemName: "scroll")
+                }
+                .buttonStyle(PlainButtonStyle())
+            }
+        }
+    }
+    
+    var destructiveActions: some View {
+        Group {
             if person?.isMe == true {
                 Button(role: context.isDeleted ? .none : .destructive) {
                     GraniteHaptic.light.invoke()
@@ -194,8 +250,10 @@ struct PostActionsView: View {
                     }
                     .buttonStyle(PlainButtonStyle())
                 }
-                
-                //TODO: report functionality/testing
+            }
+            
+            
+            //TODO: report functionality/testing
 //                Button(role: .destructive) {
 //                    GraniteHaptic.light.invoke()
 //                    switch bookmarkKind {
@@ -212,17 +270,6 @@ struct PostActionsView: View {
 //                    Text("REPORT_POST")
 //                }
 //                .buttonStyle(PlainButtonStyle())
-            }
-        } label: {
-            Image(systemName: "ellipsis")
-                .font(Device.isExpandedLayout ? .subheadline : .footnote.bold())
-                .frame(width: Device.isMacOS ? 16 : 24, height: isCompact ? 12 : 24)
-                .contentShape(Rectangle())
-                .foregroundColor(.foreground)
-                .offset(x: Device.isMacOS ? 8 : 0)
         }
-        .menuStyle(BorderlessButtonMenuStyle())
-        .menuIndicator(.hidden)
-        .frame(width: Device.isMacOS ? 20 : 24, height: 12)
     }
 }

--- a/Shared/Utility/Compressor.swift
+++ b/Shared/Utility/Compressor.swift
@@ -2,7 +2,7 @@
 //  Compressor.swift
 //  Loom
 //
-//  Created by Ritesh Pakala on 8/22/23.
+//  Created by PEXAVC on 8/22/23.
 //
 
 import Foundation

--- a/Shared/Utility/Content/Context/ContentContext.Helpers.swift
+++ b/Shared/Utility/Content/Context/ContentContext.Helpers.swift
@@ -1,0 +1,21 @@
+//
+//  ContentContext.Helpers.swift
+//  Loom
+//
+//  Created by PEXAVC on 8/26/23.
+//
+
+import Foundation
+
+extension ContentContext {
+    var viewbaleHosts: [String] {
+        var hosts = commentModel?.viewableHosts ?? postModel?.viewableHosts ?? []
+        
+        if viewingContext.isBookmark,
+           case .peer(let host) = viewingContext.bookmarkLocation {
+            hosts += [host]
+        }
+        
+        return hosts
+    }
+}

--- a/Shared/Utility/Content/Context/ContentContext.swift
+++ b/Shared/Utility/Content/Context/ContentContext.swift
@@ -72,6 +72,10 @@ struct ContentContext {
         viewingContext == .screenshot
     }
     
+    var isPreview: Bool {
+        viewingContext == .search
+    }
+    
     var isOP: Bool {
         guard let poster = postModel?.creator else {
             return false
@@ -99,6 +103,13 @@ struct ContentContext {
     static func addCommentModel(model: CommentView?, _ context: ContentContext) -> Self {
         return .init(postModel: context.postModel,
                      commentModel: model ?? context.commentModel,
+                     feedStyle: context.feedStyle,
+                     viewingContext: context.viewingContext)
+    }
+    
+    static func withPostModel(_ model: PostView?, _ context: ContentContext) -> Self {
+        return .init(postModel: model,
+                     commentModel: nil,
                      feedStyle: context.feedStyle,
                      viewingContext: context.viewingContext)
     }

--- a/Shared/Utility/Content/Interaction/ContentInteraction.swift
+++ b/Shared/Utility/Content/Interaction/ContentInteraction.swift
@@ -2,7 +2,7 @@
 //  ContentInteraction.swift
 //  Loom
 //
-//  Created by Ritesh Pakala on 8/23/23.
+//  Created by PEXAVC on 8/23/23.
 //
 
 import Foundation

--- a/Shared/Utility/Content/Updater/ContentUpdater.swift
+++ b/Shared/Utility/Content/Updater/ContentUpdater.swift
@@ -2,7 +2,7 @@
 //  ContentUpdater.swift
 //  Loom
 //
-//  Created by Ritesh Pakala on 8/23/23.
+//  Created by PEXAVC on 8/23/23.
 //
 
 import Foundation

--- a/Shared/Utility/Device.swift
+++ b/Shared/Utility/Device.swift
@@ -39,6 +39,32 @@ struct Device {
         isMacOS || isiPad
     }
     
+    static var hasNotch: Bool {
+        guard Device.isIPhone else { return false}
+        
+        #if os(iOS)
+        guard let windowScene = UIApplication.shared
+            .connectedScenes
+            .first as? UIWindowScene else {
+            LoomLog("Could not get connected scene", level: .error)
+            return false
+        }
+        
+        guard let keyWindow = windowScene.keyWindow else {
+            LoomLog("Could not get keyWindow", level: .error)
+            return false
+        }
+        
+        if UIDevice.current.orientation.isPortrait {
+            return keyWindow.safeAreaInsets.bottom > 0
+        } else {
+            return keyWindow.safeAreaInsets.left > 0 || keyWindow.safeAreaInsets.right > 0
+        }
+        #else
+        return false
+        #endif
+    }
+    
     static var appVersion: String? {
         if let releaseVersion = Bundle.main.releaseVersionNumber,
            let buildVersion = Bundle.main.buildVersionNumber {

--- a/Shared/Utility/Pager/Pager.ScrollView.swift
+++ b/Shared/Utility/Pager/Pager.ScrollView.swift
@@ -126,6 +126,7 @@ struct PagerScrollView<Model: Pageable, Header: View, AddContent: View, Content:
                     }
                 }
             }
+            .id(pager.shouldReset)
             if properties.showFetchMore {
                 PagerFooterLoadingView<Model>()
                     .environmentObject(pager)

--- a/Shared/Utility/Search/SearchConductor.swift
+++ b/Shared/Utility/Search/SearchConductor.swift
@@ -90,4 +90,9 @@ class SearchConductor: ObservableObject {
         searchTimer = nil
         self.lastQuery = ""
     }
+    
+    func reset() {
+        self.response = nil
+        self.clean()
+    }
 }

--- a/Shared/Views/AdaptsToKeyboard.swift
+++ b/Shared/Views/AdaptsToKeyboard.swift
@@ -19,8 +19,12 @@ struct AdaptsToKeyboard: ViewModifier {
             content
                 .padding(.bottom, self.currentHeight + (safeAreaAware ? UIApplication.shared.windowSafeAreaInsets.bottom : 0))
                 .onAppear(perform: {
-                    NotificationCenter.Publisher(center: NotificationCenter.default, name: UIResponder.keyboardWillShowNotification)
-                        .merge(with: NotificationCenter.Publisher(center: NotificationCenter.default, name: UIResponder.keyboardWillChangeFrameNotification))
+                    NotificationCenter
+                        .Publisher(center: NotificationCenter.default,
+                                   name: UIResponder.keyboardWillShowNotification)
+                        .merge(with: NotificationCenter
+                            .Publisher(center: NotificationCenter.default,
+                                       name: UIResponder.keyboardWillChangeFrameNotification))
                         .compactMap { notification in
                             withAnimation(.easeOut(duration: 0.16)) {
                                 notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect
@@ -31,9 +35,11 @@ struct AdaptsToKeyboard: ViewModifier {
                     }
                     .subscribe(Subscribers.Assign(object: self, keyPath: \.currentHeight))
                     
-                    NotificationCenter.Publisher(center: NotificationCenter.default, name: UIResponder.keyboardWillHideNotification)
+                    NotificationCenter
+                        .Publisher(center: NotificationCenter.default,
+                                   name: UIResponder.keyboardWillHideNotification)
                         .compactMap { notification in
-                            CGFloat.zero
+                            return CGFloat.zero
                     }
                     .subscribe(Subscribers.Assign(object: self, keyPath: \.currentHeight))
                 })

--- a/Shared/Views/Drawer/Drawer+Computed.swift
+++ b/Shared/Views/Drawer/Drawer+Computed.swift
@@ -59,5 +59,24 @@ extension Drawer {
                 .edgesIgnoringSafeArea(.all)
             }
         }
+       .onReceive(NotificationCenter
+        .Publisher(center: NotificationCenter.default,
+                   name: UIResponder.keyboardWillShowNotification)) { _ in
+           guard keyboardAware else { return }
+           DispatchQueue.main.async {
+               self.lastHeight = self.height
+               self.height = self.heightWithKeyboard.height
+               self.restingHeight = self.height
+           }
+       }
+       .onReceive(NotificationCenter
+        .Publisher(center: NotificationCenter.default,
+                   name: UIResponder.keyboardWillHideNotification)) { _ in
+           guard keyboardAware else { return }
+           DispatchQueue.main.async {
+               self.height = self.lastHeight
+               self.restingHeight = self.height
+           }
+       }
     }
 }

--- a/Shared/Views/Drawer/Drawer.swift
+++ b/Shared/Views/Drawer/Drawer.swift
@@ -17,6 +17,7 @@ public struct Drawer<Content>: View where Content: View {
     
     /// The current height of the displayed drawer
     @State public var height: CGFloat
+    @State internal var lastHeight: CGFloat = 100
     
     /// The current height marker the drawer is conformed to. Change triggers `onRest`
     @State internal var restingHeight: CGFloat {
@@ -57,6 +58,10 @@ public struct Drawer<Content>: View where Content: View {
     
     @State internal var animation: Animation? = Animation.spring()
     
+    // MARK: keyboard aware
+    var keyboardAware: Bool
+    var heightWithKeyboard: Detent
+    
     // MARK: Haptics
     
     internal var impactGenerator: UIImpactFeedbackGenerator?
@@ -78,12 +83,16 @@ public extension Drawer {
     init(
         heights: Binding<[CGFloat]> = .constant([0]),
         startingHeight: CGFloat? = nil,
+        keyboardAware: Bool = false,
+        heightWithKeyboard: Detent = .large,
         @ViewBuilder _ content: () -> Content
     ) {
         self._heights = heights
         self._height = .init(initialValue: startingHeight ?? heights.wrappedValue.first!)
         self._restingHeight = .init(initialValue: startingHeight ?? heights.wrappedValue.first!)
         self.content = content()
+        self.keyboardAware = keyboardAware
+        self.heightWithKeyboard = heightWithKeyboard
     }
 }
 
@@ -95,6 +104,8 @@ internal extension Drawer {
         height: CGFloat,
         restingHeight: CGFloat,
         springHeight: CGFloat,
+        keyboardAware: Bool = true,
+        heightWithKeyboard: Detent = .large,
         didRest: ((_ height: CGFloat) -> ())?,
         didLayoutForSizeClass: ((SizeClass) -> ())?,
         impactGenerator: UIImpactFeedbackGenerator?,
@@ -108,6 +119,8 @@ internal extension Drawer {
         self.didLayoutForSizeClass = didLayoutForSizeClass
         self.content = content
         self.impactGenerator = impactGenerator
+        self.keyboardAware = keyboardAware
+        self.heightWithKeyboard = heightWithKeyboard
     }
 }
 

--- a/Shared/Views/GenericPreview.swift
+++ b/Shared/Views/GenericPreview.swift
@@ -2,7 +2,7 @@
 //  GenericPreview.swift
 //  Loom
 //
-//  Created by Ritesh Pakala on 8/22/23.
+//  Created by PEXAVC on 8/22/23.
 //
 
 import Foundation

--- a/Shared/Views/KeyboardToolbarTextView.swift
+++ b/Shared/Views/KeyboardToolbarTextView.swift
@@ -2,7 +2,7 @@
 //  KeyboardToolbar.swift
 //  Loom
 //
-//  Created by Ritesh Pakala on 8/22/23.
+//  Created by PEXAVC on 8/22/23.
 //
 
 #if os(iOS)
@@ -239,6 +239,11 @@ final class KeyboardViewController: UIViewController, KeyboardTextToolController
                                               left: 12,
                                               bottom: 0,
                                               right: 12)
+            case .search:
+                textView.contentInset = .init(top: .layer1,
+                                              left: 0,
+                                              bottom: 0,
+                                              right: 0)
             default:
                 textView.contentInset = .init(top: 2,
                                               left: 0,
@@ -353,7 +358,7 @@ struct StyleTextKeyboardTool: KeyboardTool {
     enum Kind: String {
         case bold = "**"
         case italic = "*"
-        case strikethrough = "~"
+        case strikethrough = "~~"
         
         var symbolName: String {
             switch self {


### PR DESCRIPTION
New Features:
- add another option to reply to comments without having to swipe to reply (three dots button)
- allow the modal to rest at a lower position
- thread drawer appears everywhere
- replying to thread pushes navigation window into modal stack 
- Post/Comment actions (three dots button) allow for thread viewing and replying

Bugs:
- Censored posts in search do not trigger to view its content
- share button in search does not work
- search is reset when new account is logged into
- Thread modals were not updating per breadcrumb
- iPhone SE Bottom tab bar (devices with no notch)
- strikethrough md helper was wrong amount of tildas
- add timeout to Rich link preview fetching (feed could hang, otherwise)
- macOS pager feed does not reset when entering a new community
- When entering a post from a comment, the view is confused whether the context is the post or comment
- Expand/raise drawer when keyboard is active