### PR TITLE
v1.1.0b(2023.8.30)

### DIFF
--- a/Components/Feed/Feed+View.swift
+++ b/Components/Feed/Feed+View.swift
@@ -25,10 +25,11 @@ extension Feed: GraniteNavigationDestination {
             }
         }
         .background(Color.background)
-        //Careful of expanded layout
-        .graniteNavigationDestinationIf(isCommunity) {
-            communityInfoMenuView
-        }
+//        //Careful of expanded layout
+//        .graniteNavigationDestinationIf(isCommunity,
+//                                        fullWidth: true) {
+//            communityInfoMenuView
+//        }
         .task {
             guard pager.isEmpty else { return }
             
@@ -64,7 +65,6 @@ extension Feed: GraniteNavigationDestination {
     }
     
     var destinationStyle: GraniteNavigationDestinationStyle {
-        .init(navBarBGColor: Color.background,
-              isCustomTrailing: isCommunity)
+        .custom()
     }
 }

--- a/Components/Feed/Feed.swift
+++ b/Components/Feed/Feed.swift
@@ -11,6 +11,9 @@ struct Feed: GraniteComponent {
     @Relay var account: AccountService
     @Relay var loom: LoomService
     
+    @Environment(\.graniteNavigationStyle) var navigationStyle
+    @Environment(\.graniteRouter) var router
+    
     /*
      Note: there is no "LayoutService" in the top level.
      Avoid redraws, as for Expanded layout manages 3 different

--- a/Components/Feed/Views/Feed.CommunityInfoView.swift
+++ b/Components/Feed/Views/Feed.CommunityInfoView.swift
@@ -155,7 +155,7 @@ struct FeedCommunityInfoMenuView: View {
             }
         } label: {
             Image(systemName: "ellipsis")
-                .font(Device.isExpandedLayout ? .title : .title3)
+                .font(.title2)
                 .frame(width: Device.isMacOS ? 16 : 24, height: 24)
                 .contentShape(Rectangle())
                 .foregroundColor(.foreground)

--- a/Components/Feed/Views/Header/Feed.HeaderView.swift
+++ b/Components/Feed/Views/Header/Feed.HeaderView.swift
@@ -28,6 +28,26 @@ extension Feed {
             if Device.isExpandedLayout {
                 accountExpandedMenuView
                     .padding(.horizontal, Device.isExpandedLayout ? .layer3 : .layer4)
+            } else if isCommunity {
+                HStack(spacing: 0) {
+                    navigationStyle
+                        .leadingItem
+                        .frame(width: 24, height: 24)
+                        .readabilityIf(hasCommunityBanner, cornerRadius: 4, padding: 6)
+                        .onTapGesture {
+                            GraniteHaptic.light.invoke()
+                            router.pop()
+                        }
+                    
+                    Spacer()
+                    
+                    //readability handled inside
+                    communityInfoMenuView
+                        .readabilityIf(hasCommunityBanner, cornerRadius: 4, padding: 6)
+                }
+                .padding(.horizontal, .layer4)
+                .padding(.top, .layer3)
+                .padding(.bottom, hasCommunityBanner == false ? .layer2 : 0)
             }
             
             titleBarView
@@ -81,6 +101,7 @@ extension Feed {
             
             Divider()
         }
+        .padding(.top, headerPaddingTop)
         .background(Color.background.overlayIf(state.community != nil) {
             if let banner = state.community?.banner,
                let url = URL(string: banner) {
@@ -99,6 +120,18 @@ extension Feed {
             }
         }
         .clipped())
+    }
+    
+    var headerPaddingTop: CGFloat {
+        #if os(iOS)
+        if Device.isIPhone {
+            return UIApplication.shared.windowSafeAreaInsets.top
+        } else {
+            return 0
+        }
+        #else
+        return 0
+        #endif
     }
     
     var pagerIndicatorView: some View {

--- a/Components/Feed/Views/Layout/Feed.Vertical.swift
+++ b/Components/Feed/Views/Layout/Feed.Vertical.swift
@@ -30,11 +30,23 @@ extension Feed {
                 }, at: \.write))
              .environmentObject(pager)
         }
-        .edgesIgnoringSafeArea(state.community != nil ? [.bottom] : [])
+        .edgesIgnoringSafeArea(edgesToIgnore)
         .sideMenuIf(state.community == nil && Device.isExpandedLayout == false,
                     isShowing: _state.isShowing) {
             accountExpandedMenuView
                 .id("\(account.state.profiles.count)\(account.state.authenticated)")
+        }
+    }
+    
+    var edgesToIgnore: Edge.Set {
+        if isCommunity {
+            if Device.isIPhone {
+                return [.bottom, .top]
+            } else {
+                return [.bottom]
+            }
+        } else {
+            return []
         }
     }
 }

--- a/Components/Feed/Views/Layout/FeedHamburgerView.swift
+++ b/Components/Feed/Views/Layout/FeedHamburgerView.swift
@@ -59,6 +59,7 @@ extension Feed {
                                reset: true)
             }, at: \.changeLocation)
             .id(account.state.meta)
+            .padding(.top, headerPaddingTop)
     }
 }
 

--- a/Components/Feed/Views/Layout/FeedMainView.swift
+++ b/Components/Feed/Views/Layout/FeedMainView.swift
@@ -33,7 +33,8 @@ struct FeedMainView<Content: View>: View {
     var body: some View {
         PagerScrollView(PostView.self,
                         properties: .init(alternateContentPosition: true,
-                                          performant: true),
+                                          performant: true,
+                                          hidingHeader: true),
                         header: header) {
             EmptyView()
         } content: { postView in

--- a/Components/Feed/Views/Layout/FeedMainView.swift
+++ b/Components/Feed/Views/Layout/FeedMainView.swift
@@ -34,7 +34,8 @@ struct FeedMainView<Content: View>: View {
         PagerScrollView(PostView.self,
                         properties: .init(alternateContentPosition: true,
                                           performant: true,
-                                          hidingHeader: true),
+                                          hidingHeader: true,
+                                          backgroundColor: Color.background),
                         header: header) {
             EmptyView()
         } content: { postView in

--- a/Components/Home/Home+View.swift
+++ b/Components/Home/Home+View.swift
@@ -70,7 +70,7 @@ extension Home: View {
             Color.background.fitToContainer()
             
         }, currentTab: 0) {
-            GraniteTab {
+            GraniteTab(ignoreEdges: [.top]) {
                 Feed()
             } icon: {
                 GraniteTabIcon(name: "house")
@@ -119,8 +119,7 @@ extension Home: View {
                 }
             }
         }
-        .edgesIgnoringSafeArea([.top, .bottom])
-        .padding(.top, safeAreaTop)
+        .edgesIgnoringSafeArea([.bottom])
         .graniteNavigation(backgroundColor: Color.background) {
             Image(systemName: "chevron.backward")
                 .renderingMode(.template)

--- a/Components/Loom/Loom+View.swift
+++ b/Components/Loom/Loom+View.swift
@@ -112,7 +112,7 @@ extension Loom: View {
                             }
                         }, at: \.edit)
                 case .communities:
-                    CommunityPickerView(modal: false, verticalPadding: 0)
+                    CommunityPickerView(modal: false, shouldRoute: true, verticalPadding: 0)
                 }
             }
             
@@ -155,7 +155,9 @@ extension Loom {
             
             Divider()
             
-            CommunityPickerView(modal: false, verticalPadding: 0)
+            CommunityPickerView(modal: false,
+                                shouldRoute: true,
+                                verticalPadding: 0)
         }
     }
 }

--- a/Components/Search/Views/Search.AllView.swift
+++ b/Components/Search/Views/Search.AllView.swift
@@ -175,6 +175,7 @@ struct SearchAllView: View {
                                                               viewingContext: .search).withStyle(.style2))
                                         .frame(minWidth: ContainerConfig.iPhoneScreenWidth * 0.8, maxWidth: Device.isExpandedLayout ? 450 : ContainerConfig.iPhoneScreenWidth * 0.9)
                                         .frame(height: 240)
+                                        .padding(.bottom, .layer2)
                                     
                                     if commentView.id != model.comments.last?.id {
                                         

--- a/Components/Write/Reducers/Write.Create.swift
+++ b/Components/Write/Reducers/Write.Create.swift
@@ -12,7 +12,6 @@ extension Write {
             var postView: PostView
         }
         
-        @Environment(\.graniteRouter) var router
         @Relay var config: ConfigService
         
         func reduce(state: inout Center.State) async {
@@ -79,7 +78,10 @@ extension Write {
                 state.createdPostView = value
                 state.showPost = true
                 
-                router.push(style: .customTrailing()) {
+                
+                GraniteNavigation
+                    .router(for: state.routerId)
+                    .push(style: .customTrailing(Color.background)) {
                     PostDisplayView()
                         .contentContext(.init(postModel: value))
                 }

--- a/Components/Write/Write+Center.swift
+++ b/Components/Write/Write+Center.swift
@@ -26,6 +26,8 @@ extension Write {
             var createdPostView: PostView? = nil
             
             var isPosting: Bool = false
+            
+            var routerId: String = ""
         }
         
         @Event(debounce: 0.25) var create: Write.Create.Reducer

--- a/Components/Write/Write+View.swift
+++ b/Components/Write/Write+View.swift
@@ -132,6 +132,7 @@ extension Write: View {
                         
                         GraniteHaptic.light.invoke()
                         _state.isPosting.wrappedValue = true
+                        _state.routerId.wrappedValue = router.id
                         center.create.send()
                     } label: {
                         Image(systemName: state.isEditing ? "sdcard.fill" : "paperplane.fill")

--- a/Components/Write/Write.swift
+++ b/Components/Write/Write.swift
@@ -11,6 +11,8 @@ struct Write: GraniteComponent {
     
     @GraniteAction<PostView> var updatedPost
     
+    @Environment(\.graniteRouter) var router
+    
     static var modalId: String = "loom.write.view.sheets"
     
     enum Kind {

--- a/Loom--iOS--Info.plist
+++ b/Loom--iOS--Info.plist
@@ -7,5 +7,7 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<false/>
 </dict>
 </plist>

--- a/Loom.xcodeproj/project.pbxproj
+++ b/Loom.xcodeproj/project.pbxproj
@@ -3546,6 +3546,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = "Launch Screen.storyboard";
 				INFOPLIST_KEY_UIRequiresFullScreen = YES;
+				INFOPLIST_KEY_UIStatusBarHidden = NO;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
@@ -3581,6 +3582,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = "Launch Screen.storyboard";
 				INFOPLIST_KEY_UIRequiresFullScreen = YES;
+				INFOPLIST_KEY_UIStatusBarHidden = NO;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.4;

--- a/Loom.xcodeproj/project.pbxproj
+++ b/Loom.xcodeproj/project.pbxproj
@@ -849,7 +849,6 @@
 		717090ED2A7EEF66009F1FB7 /* FeedExtendedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedExtendedView.swift; sourceTree = "<group>"; };
 		7178FCBE2A9E598100E9BA96 /* Pager.ScrollView.HidingHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pager.ScrollView.HidingHeader.swift; sourceTree = "<group>"; };
 		7178FCC22A9E8E0D00E9BA96 /* GraniteScrollView+Proxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraniteScrollView+Proxy.swift"; sourceTree = "<group>"; };
-		7178FCC52A9ED41000E9BA96 /* Granite */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = Granite; path = ../../../pexavc/repositories/Granite; sourceTree = "<group>"; };
 		717C129E293BEF730060A446 /* AppBlurBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppBlurBackground.swift; sourceTree = "<group>"; };
 		717C12A2293BF03C0060A446 /* Animations._.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Animations._.swift; sourceTree = "<group>"; };
 		717C8FB42A6F9F3D00DF6037 /* Pager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pager.swift; sourceTree = "<group>"; };
@@ -1393,7 +1392,6 @@
 		711B3F6C2885D43700F3080D = {
 			isa = PBXGroup;
 			children = (
-				7178FCC52A9ED41000E9BA96 /* Granite */,
 				7157977B2A7B86F000B7FEC9 /* .gitignore */,
 				7157977A2A7B86D600B7FEC9 /* README.md */,
 				719725FD28CC864400A64334 /* Loom--iOS--Info.plist */,
@@ -3534,7 +3532,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2023.8.29;
+				CURRENT_PROJECT_VERSION = 2023.8.30;
 				DEVELOPMENT_TEAM = CV8LAA8JAP;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -3570,7 +3568,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2023.8.29;
+				CURRENT_PROJECT_VERSION = 2023.8.30;
 				DEVELOPMENT_TEAM = CV8LAA8JAP;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -3609,7 +3607,7 @@
 				CODE_SIGN_ENTITLEMENTS = macOS/macOS.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 2023.8.29;
+				CURRENT_PROJECT_VERSION = 2023.8.30;
 				DEVELOPMENT_TEAM = CV8LAA8JAP;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
@@ -3639,7 +3637,7 @@
 				CODE_SIGN_ENTITLEMENTS = macOS/macOS.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 2023.8.29;
+				CURRENT_PROJECT_VERSION = 2023.8.30;
 				DEVELOPMENT_TEAM = CV8LAA8JAP;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;

--- a/Loom.xcodeproj/project.pbxproj
+++ b/Loom.xcodeproj/project.pbxproj
@@ -848,8 +848,8 @@
 		717090E82A7EEF0B009F1FB7 /* LayoutService+Center.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "LayoutService+Center.swift"; sourceTree = "<group>"; };
 		717090ED2A7EEF66009F1FB7 /* FeedExtendedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedExtendedView.swift; sourceTree = "<group>"; };
 		7178FCBE2A9E598100E9BA96 /* Pager.ScrollView.HidingHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pager.ScrollView.HidingHeader.swift; sourceTree = "<group>"; };
-		7178FCC12A9E7D6E00E9BA96 /* Granite */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = Granite; path = ../../../pexavc/repositories/Granite; sourceTree = "<group>"; };
 		7178FCC22A9E8E0D00E9BA96 /* GraniteScrollView+Proxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraniteScrollView+Proxy.swift"; sourceTree = "<group>"; };
+		7178FCC52A9ED41000E9BA96 /* Granite */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = Granite; path = ../../../pexavc/repositories/Granite; sourceTree = "<group>"; };
 		717C129E293BEF730060A446 /* AppBlurBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppBlurBackground.swift; sourceTree = "<group>"; };
 		717C12A2293BF03C0060A446 /* Animations._.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Animations._.swift; sourceTree = "<group>"; };
 		717C8FB42A6F9F3D00DF6037 /* Pager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pager.swift; sourceTree = "<group>"; };
@@ -1393,7 +1393,7 @@
 		711B3F6C2885D43700F3080D = {
 			isa = PBXGroup;
 			children = (
-				7178FCC12A9E7D6E00E9BA96 /* Granite */,
+				7178FCC52A9ED41000E9BA96 /* Granite */,
 				7157977B2A7B86F000B7FEC9 /* .gitignore */,
 				7157977A2A7B86D600B7FEC9 /* README.md */,
 				719725FD28CC864400A64334 /* Loom--iOS--Info.plist */,

--- a/Loom.xcodeproj/project.pbxproj
+++ b/Loom.xcodeproj/project.pbxproj
@@ -267,6 +267,10 @@
 		717090EC2A7EEF0B009F1FB7 /* LayoutService+Center.swift in Sources */ = {isa = PBXBuildFile; fileRef = 717090E82A7EEF0B009F1FB7 /* LayoutService+Center.swift */; };
 		717090EE2A7EEF66009F1FB7 /* FeedExtendedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 717090ED2A7EEF66009F1FB7 /* FeedExtendedView.swift */; };
 		717090EF2A7EEF66009F1FB7 /* FeedExtendedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 717090ED2A7EEF66009F1FB7 /* FeedExtendedView.swift */; };
+		7178FCBF2A9E598100E9BA96 /* Pager.ScrollView.HidingHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7178FCBE2A9E598100E9BA96 /* Pager.ScrollView.HidingHeader.swift */; };
+		7178FCC02A9E598100E9BA96 /* Pager.ScrollView.HidingHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7178FCBE2A9E598100E9BA96 /* Pager.ScrollView.HidingHeader.swift */; };
+		7178FCC32A9E8E0D00E9BA96 /* GraniteScrollView+Proxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7178FCC22A9E8E0D00E9BA96 /* GraniteScrollView+Proxy.swift */; };
+		7178FCC42A9E8E0D00E9BA96 /* GraniteScrollView+Proxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7178FCC22A9E8E0D00E9BA96 /* GraniteScrollView+Proxy.swift */; };
 		717C129F293BEF730060A446 /* AppBlurBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 717C129E293BEF730060A446 /* AppBlurBackground.swift */; };
 		717C12A0293BEF730060A446 /* AppBlurBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 717C129E293BEF730060A446 /* AppBlurBackground.swift */; };
 		717C12A3293BF03C0060A446 /* Animations._.swift in Sources */ = {isa = PBXBuildFile; fileRef = 717C12A2293BF03C0060A446 /* Animations._.swift */; };
@@ -843,6 +847,9 @@
 		717090E62A7EEF0B009F1FB7 /* LayoutService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LayoutService.swift; sourceTree = "<group>"; };
 		717090E82A7EEF0B009F1FB7 /* LayoutService+Center.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "LayoutService+Center.swift"; sourceTree = "<group>"; };
 		717090ED2A7EEF66009F1FB7 /* FeedExtendedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedExtendedView.swift; sourceTree = "<group>"; };
+		7178FCBE2A9E598100E9BA96 /* Pager.ScrollView.HidingHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pager.ScrollView.HidingHeader.swift; sourceTree = "<group>"; };
+		7178FCC12A9E7D6E00E9BA96 /* Granite */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = Granite; path = ../../../pexavc/repositories/Granite; sourceTree = "<group>"; };
+		7178FCC22A9E8E0D00E9BA96 /* GraniteScrollView+Proxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraniteScrollView+Proxy.swift"; sourceTree = "<group>"; };
 		717C129E293BEF730060A446 /* AppBlurBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppBlurBackground.swift; sourceTree = "<group>"; };
 		717C12A2293BF03C0060A446 /* Animations._.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Animations._.swift; sourceTree = "<group>"; };
 		717C8FB42A6F9F3D00DF6037 /* Pager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pager.swift; sourceTree = "<group>"; };
@@ -1386,6 +1393,7 @@
 		711B3F6C2885D43700F3080D = {
 			isa = PBXGroup;
 			children = (
+				7178FCC12A9E7D6E00E9BA96 /* Granite */,
 				7157977B2A7B86F000B7FEC9 /* .gitignore */,
 				7157977A2A7B86D600B7FEC9 /* README.md */,
 				719725FD28CC864400A64334 /* Loom--iOS--Info.plist */,
@@ -2034,6 +2042,7 @@
 				717C8FB42A6F9F3D00DF6037 /* Pager.swift */,
 				71C8BE712A7F2BF1008694C7 /* Pager.ScrollView.swift */,
 				71FF5BFD2A9C118F00DD83EB /* Pager.ScrollView.Simple.swift */,
+				7178FCBE2A9E598100E9BA96 /* Pager.ScrollView.HidingHeader.swift */,
 				71FF5BFA2A9C0EB000DD83EB /* Pager.ScrollView.Partition.swift */,
 				71FF5BF32A9C046800DD83EB /* Pager.ListView.swift */,
 				71C8BE742A7F2BFA008694C7 /* Pager.LoadingView.swift */,
@@ -2408,6 +2417,7 @@
 				71FBA7F6296D16110090B630 /* GraniteScrollViewStyle.swift */,
 				71FBA7F3296D16110090B630 /* GranitePagingView.swift */,
 				71FBA7F5296D16110090B630 /* GraniteScrollView.swift */,
+				7178FCC22A9E8E0D00E9BA96 /* GraniteScrollView+Proxy.swift */,
 				7151512E2A8FBE0D00251978 /* GraniteScrollView+macOS.swift */,
 			);
 			path = GraniteScrollView;
@@ -2747,6 +2757,7 @@
 				71F042262A6A3AD700788CDC /* Write+View.swift in Sources */,
 				71C5FF682A64688B00F99A84 /* Drawer+Modifiers.swift in Sources */,
 				717C8FB82A6FCBAD00DF6037 /* Feed.CommunityInfoView.swift in Sources */,
+				7178FCC32A9E8E0D00E9BA96 /* GraniteScrollView+Proxy.swift in Sources */,
 				71FCDD062A759EBF000A6309 /* BannerView.swift in Sources */,
 				71EB91BD2A8028400091EE5B /* Numbers.swift in Sources */,
 				71071F222A660D8E003AEC62 /* PostContentView.swift in Sources */,
@@ -2941,6 +2952,7 @@
 				7166E9C92A74457A004F88D7 /* CommunitySidebarView.swift in Sources */,
 				710283872A2A54C300010877 /* RangeSliderStyleConfiguration.swift in Sources */,
 				71C8BE782A7F2E1E008694C7 /* ContentMetadataView.swift in Sources */,
+				7178FCBF2A9E598100E9BA96 /* Pager.ScrollView.HidingHeader.swift in Sources */,
 				71622EA12A6E5796006233F3 /* Reply+View.swift in Sources */,
 				71C9F8FE2A60B9460089D7EA /* ConfigService.swift in Sources */,
 				71FBA7FB296D16110090B630 /* GraniteScrollViewPositionIndicator.swift in Sources */,
@@ -3037,6 +3049,7 @@
 				71C8BE792A7F2E1E008694C7 /* ContentMetadataView.swift in Sources */,
 				7102839A2A2A54C300010877 /* PointSliderStyle.swift in Sources */,
 				71F778BD2A71A95300C9C5C4 /* SfSafariView.swift in Sources */,
+				7178FCC42A9E8E0D00E9BA96 /* GraniteScrollView+Proxy.swift in Sources */,
 				71C9F9452A613EA30089D7EA /* BookmarkService.Modify.swift in Sources */,
 				71EAF47A2A7DA3320034FCB9 /* ExplorerService+Center.swift in Sources */,
 				71FF5BFF2A9C118F00DD83EB /* Pager.ScrollView.Simple.swift in Sources */,
@@ -3169,6 +3182,7 @@
 				71A28D99295231E600EAE8EE /* Color.swift in Sources */,
 				712C0D7E2A7CA32500DBDCC9 /* CGPoint.swift in Sources */,
 				71A4A1172A61C39600689DF2 /* Bookmark.swift in Sources */,
+				7178FCC02A9E598100E9BA96 /* Pager.ScrollView.HidingHeader.swift in Sources */,
 				71C9F8D72A60B7C10089D7EA /* Feed+Center.swift in Sources */,
 				71F042252A6A3AD700788CDC /* Write.swift in Sources */,
 				711B3FDE2885D4F000F3080D /* Home.swift in Sources */,

--- a/Loom.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Loom.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -10,6 +10,15 @@
       }
     },
     {
+      "identity" : "granite",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pexavc/Granite.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "69de0f49bd009fa4ba301edee62672d042e4f420"
+      }
+    },
+    {
       "identity" : "highlightr",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/raspu/Highlightr.git",

--- a/Loom.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Loom.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -10,15 +10,6 @@
       }
     },
     {
-      "identity" : "granite",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pexavc/Granite.git",
-      "state" : {
-        "branch" : "main",
-        "revision" : "3c507a5cfb07596a18e4b7cd920e824b457ecc69"
-      }
-    },
-    {
       "identity" : "highlightr",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/raspu/Highlightr.git",

--- a/Services/ConfigService/Models/InstanceConfig.swift
+++ b/Services/ConfigService/Models/InstanceConfig.swift
@@ -19,7 +19,7 @@ struct InstanceConfig: GraniteModel, Hashable {
 
 extension InstanceConfig {
     static var `default`: InstanceConfig {
-        .init(baseUrl: "https://lemmy.world")
+        .init(baseUrl: "https://neatia.xyz")
     }
 }
 

--- a/Services/ModalService/ModalService.swift
+++ b/Services/ModalService/ModalService.swift
@@ -28,15 +28,15 @@ struct ModalService : GraniteService {
     
     static var alertViewStyle: GraniteAlertViewStyle {
         GraniteAlertViewStyle(backgroundColor: Color.background,
-                              foregroundColor: Color.white,
+                              foregroundColor: Color.foreground,
                               actionColor: Color.foreground,
                               overlayColor: Color.red,
                               sheetVerticalPadding: 15)
     }
     
     static var toastStyle: GraniteToastViewStyle {
-        GraniteToastViewStyle(backgroundColor: Color.background,
-                              foregroundColor: Color.white)
+        GraniteToastViewStyle(backgroundColor: Color.alternateBackground.opacity(0.8),
+                              foregroundColor: Color.foreground)
     }
     
     let modalManager = GraniteModalManager { view in

--- a/Services/ModalService/ModalService.swift
+++ b/Services/ModalService/ModalService.swift
@@ -35,7 +35,7 @@ struct ModalService : GraniteService {
     }
     
     static var toastStyle: GraniteToastViewStyle {
-        GraniteToastViewStyle(backgroundColor: Color.alternateBackground.opacity(0.8),
+        GraniteToastViewStyle(backgroundColor: Color.alternateBackground.opacity(0.9),
                               foregroundColor: Color.foreground)
     }
     

--- a/Services/ModalService/Views/Sheet/GraniteSheetContainerView.swift
+++ b/Services/ModalService/Views/Sheet/GraniteSheetContainerView.swift
@@ -255,6 +255,7 @@ fileprivate extension View {
                             
                             Divider()
                                 .padding(.top, .layer4)
+                                .padding(.bottom, .layer2)
                             
                             content()
                                 .adaptsToKeyboard(safeAreaAware: true)

--- a/Services/ModalService/Views/Toast/GraniteToastView.swift
+++ b/Services/ModalService/Views/Toast/GraniteToastView.swift
@@ -46,14 +46,16 @@ public struct GraniteToastView : GraniteModal {
         .padding(.vertical, 12)
         .background(ZStack {
             RoundedRectangle(cornerRadius: 10)
-                .fill(Color.black)
+                .fill(style.backgroundColor)
+                //.blur(radius: 6)
             RoundedRectangle(cornerRadius: 10)
                 .fill(style.color(for: event))
+                .blur(radius: 2)
                 .shadow(color: Color.black.opacity(0.05), radius: 10)
         })
         .overlay(
             RoundedRectangle(cornerRadius: 10)
-                .stroke(Color.gray.opacity(0.3))
+                .stroke(Color.secondaryForeground.opacity(0.3))
         )
         .padding(.horizontal, .layer3)
         .padding(.top, 16)
@@ -74,64 +76,5 @@ public struct GraniteToastView : GraniteModal {
             timerCancellable?.cancel()
             manager.dismiss()
         }
-    }
-    
-}
-
-struct GraniteToastView_Previews: PreviewProvider {
-    
-    static var toast : some View {
-        GraniteToastView(title: "Generic message",
-                         message: "This is neither good nor bad. Figure out what to do with this.")
-        .graniteToastViewStyle(
-            GraniteToastViewStyle(backgroundColor: Color.blue,
-                                  foregroundColor: Color.white)
-        )
-    }
-    
-    static var successToast : some View {
-        GraniteToastView(title: "Very good",
-                         message: "Something very good happened. And this is good news!",
-                         event: .success)
-            .graniteToastViewStyle(
-                GraniteToastViewStyle(backgroundColor: Color.blue,
-                                      foregroundColor: Color.white)
-            )
-    }
-    
-    static var errorToast : some View {
-        GraniteToastView(title: "Network error",
-                         message: "Something bad happened with network during the request. Try again!",
-                         event: .error)
-            .graniteToastViewStyle(
-                GraniteToastViewStyle(backgroundColor: Color.blue,
-                                      foregroundColor: Color.white)
-            )
-    }
-    
-    static var previews: some View {
-        Group {
-            VStack {
-                Spacer()
-                toast
-                Spacer()
-                successToast
-                Spacer()
-                errorToast
-                Spacer()
-            }
-            .preferredColorScheme(.dark)
-            
-            VStack {
-                Spacer()
-                toast
-                Spacer()
-                successToast
-                Spacer()
-                errorToast
-                Spacer()
-            }
-        }
-        .background(Color.white.opacity(0.1))
     }
 }

--- a/Services/ModalService/Views/Toast/GraniteToastView.swift
+++ b/Services/ModalService/Views/Toast/GraniteToastView.swift
@@ -47,16 +47,15 @@ public struct GraniteToastView : GraniteModal {
         .background(ZStack {
             RoundedRectangle(cornerRadius: 10)
                 .fill(style.backgroundColor)
-                //.blur(radius: 6)
+                .blur(radius: 2)
+                .shadow(color: Color.black.opacity(0.05), radius: 8)
             RoundedRectangle(cornerRadius: 10)
                 .fill(style.color(for: event))
-                .blur(radius: 2)
-                .shadow(color: Color.black.opacity(0.05), radius: 10)
         })
-        .overlay(
-            RoundedRectangle(cornerRadius: 10)
-                .stroke(Color.secondaryForeground.opacity(0.3))
-        )
+//        .overlay(
+//            RoundedRectangle(cornerRadius: 10)
+//                .stroke(Color.secondaryForeground.opacity(0.3))
+//        )
         .padding(.horizontal, .layer3)
         .padding(.top, 16)
         .transition(

--- a/Services/ModalService/Views/Toast/GraniteToastViewStyle.swift
+++ b/Services/ModalService/Views/Toast/GraniteToastViewStyle.swift
@@ -8,10 +8,10 @@ public struct GraniteToastViewStyle {
     public var errorBackgroundColor : Color
     public var successBackgroundColor : Color
     
-    public init(backgroundColor : Color = .black,
-                foregroundColor : Color = .white,
-                errorBackgroundColor : Color = Color.red.opacity(0.6),
-                successBackgroundColor : Color = Color.green.opacity(0.6)) {
+    public init(backgroundColor : Color = Color.alternateBackground.opacity(0.8),
+                foregroundColor : Color = Color.foreground,
+                errorBackgroundColor : Color = Color.red.opacity(0.4),
+                successBackgroundColor : Color = Color.green.opacity(0.4)) {
         self.backgroundColor = backgroundColor
         self.foregroundColor = foregroundColor
         self.errorBackgroundColor = errorBackgroundColor

--- a/Shared/Extensions/ScrollView+Overflow.swift
+++ b/Shared/Extensions/ScrollView+Overflow.swift
@@ -16,6 +16,8 @@ extension View {
             ScrollView([axis], showsIndicators: false) {
                 self
             }
+            //TODO: customizable
+            .frame(minHeight: axis.contains(.vertical) ? 300 : nil)
         } else {
             self
         }

--- a/Shared/Extensions/ScrollView+Overflow.swift
+++ b/Shared/Extensions/ScrollView+Overflow.swift
@@ -23,13 +23,13 @@ extension View {
 }
 
 extension View {
-    func scrollOnOverflow() -> some View {
-        modifier(OverflowContentViewModifier())
+    func scrollOnOverflow(axis: Axis.Set = .horizontal) -> some View {
+        modifier(OverflowContentViewModifier(axisSet: axis))
     }
-    func scrollOnOverflowIf(_ condition: Bool) -> some View {
+    func scrollOnOverflowIf(_ condition: Bool, axis: Axis.Set = .horizontal) -> some View {
         Group {
             if condition {
-                self.modifier(OverflowContentViewModifier())
+                self.modifier(OverflowContentViewModifier(axisSet: axis))
             } else {
                 self
             }
@@ -40,17 +40,25 @@ extension View {
 struct OverflowContentViewModifier: ViewModifier {
     @State private var contentOverflow: Bool = false
     
+    var axisSet: Axis.Set
     func body(content: Content) -> some View {
         GeometryReader { geometry in
             content
             .background(
                 GeometryReader { contentGeometry in
                     Color.clear.onAppear {
-                        contentOverflow = contentGeometry.size.width > geometry.size.width
+                        if axisSet.contains(.horizontal) {
+                            contentOverflow = contentGeometry.size.width > geometry.size.width
+                            
+                        }
+                        
+                        if axisSet.contains(.vertical) {
+                            contentOverflow = contentGeometry.size.height > geometry.size.height || contentOverflow
+                        }
                     }
                 }
             )
-            .wrappedInScrollView(when: contentOverflow)
+            .wrappedInScrollView(when: contentOverflow, axis: axisSet)
         }
     }
 }

--- a/Shared/Extensions/View+Readability.swift
+++ b/Shared/Extensions/View+Readability.swift
@@ -20,10 +20,23 @@ extension View {
             }
     }
     
+    func readabilityIf(_ condition: Bool,
+                       cornerRadius: CGFloat = 8,
+                       padding: CGFloat? = nil,
+                       bgColor: Color = .secondaryBackground.opacity(0.75)) -> some View {
+        Group {
+            if condition {
+                self.readability(cornerRadius: cornerRadius, padding: padding, bgColor: bgColor)
+            } else {
+                self
+            }
+        }
+    }
     func readability(cornerRadius: CGFloat = 8,
-                     bgColor: Color = .secondaryBackground) -> some View {
+                     padding: CGFloat? = nil,
+                     bgColor: Color = .secondaryBackground.opacity(0.75)) -> some View {
         self
-            .padding(.layer3)
+            .padding(padding ?? .layer3)
             .background(bgColor)
             .cornerRadius(cornerRadius)
     }

--- a/Shared/LAViews/Community/CommunityCardView.swift
+++ b/Shared/LAViews/Community/CommunityCardView.swift
@@ -129,40 +129,42 @@ struct CommunityCardView: View {
                 AvatarView(model.iconURL, size: .large, isCommunity: true)
                 
                 VStack(alignment: .leading, spacing: 0) {
-                    HStack {
-                        Text("\(subscribers) COMMUNITY_SUBSCRIBERS")
-                            .font(.headline.bold())
-                        
-                        Spacer()
-                    }
-                    
-                    HStack(spacing: .layer1) {
-                        Text(model.community.title)
-                            .font(showCounts ? .headline.bold() : .footnote.bold())
-                            .lineLimit(1)
-                            .cornerRadius(4)
-                        
-                        Spacer()
-                    }//.scrollOnOverflow()
-                    
                     Group {
-                        HStack(spacing: .layer1) {
-                            Text("!"+model.community.name)
-                                .font(.subheadline)
-                                .cornerRadius(4)
-                            Text("\(peerHost ?? "")@" + model.community.actor_id.host)
-                                .font(.caption2)
-                                .lineLimit(1)
-                                .padding(.vertical, .layer1)
-                                .padding(.horizontal, .layer1)
-                                .background(Color.tertiaryBackground)
-                                .cornerRadius(4)
+                        HStack {
+                            Text("\(subscribers) COMMUNITY_SUBSCRIBERS")
+                                .font(.headline.bold())
+                            
+                            Spacer()
                         }
                         
-                        Spacer()
+                        HStack(spacing: .layer1) {
+                            Text(model.community.title)
+                                .font(showCounts ? .headline.bold() : .footnote.bold())
+                                .lineLimit(1)
+                                .cornerRadius(4)
+                            
+                            Spacer()
+                        }//.scrollOnOverflow()
+                        
+                        Group {
+                            HStack(spacing: .layer1) {
+                                Text("!"+model.community.name)
+                                    .font(.subheadline)
+                                    .cornerRadius(4)
+                                Text("\(peerHost ?? "")@" + model.community.actor_id.host)
+                                    .font(.caption2)
+                                    .lineLimit(1)
+                                    .padding(.vertical, .layer1)
+                                    .padding(.horizontal, .layer1)
+                                    .background(Color.tertiaryBackground)
+                                    .cornerRadius(4)
+                            }
+                            
+                            Spacer()
+                        }
                     }
+                    .offset(y: .layer1)
                 }
-                .offset(y: .layer1)
                 .onTapGesture {
                     routeCommunityView()
                 }

--- a/Shared/LAViews/Community/CommunityCardView.swift
+++ b/Shared/LAViews/Community/CommunityCardView.swift
@@ -129,42 +129,40 @@ struct CommunityCardView: View {
                 AvatarView(model.iconURL, size: .large, isCommunity: true)
                 
                 VStack(alignment: .leading, spacing: 0) {
-                    Group {
-                        HStack {
-                            Text("\(subscribers) COMMUNITY_SUBSCRIBERS")
-                                .font(.headline.bold())
-                            
-                            Spacer()
-                        }
+                    HStack {
+                        Text("\(subscribers) COMMUNITY_SUBSCRIBERS")
+                            .font(.headline.bold())
                         
-                        HStack(spacing: .layer1) {
-                            Text(model.community.title)
-                                .font(showCounts ? .headline.bold() : .footnote.bold())
-                                .lineLimit(1)
-                                .cornerRadius(4)
-                            
-                            Spacer()
-                        }//.scrollOnOverflow()
-                        
-                        Group {
-                            HStack(spacing: .layer1) {
-                                Text("!"+model.community.name)
-                                    .font(.subheadline)
-                                    .cornerRadius(4)
-                                Text("\(peerHost ?? "")@" + model.community.actor_id.host)
-                                    .font(.caption2)
-                                    .lineLimit(1)
-                                    .padding(.vertical, .layer1)
-                                    .padding(.horizontal, .layer1)
-                                    .background(Color.tertiaryBackground)
-                                    .cornerRadius(4)
-                            }
-                            
-                            Spacer()
-                        }
+                        Spacer()
                     }
-                    .offset(y: .layer1)
+                    
+                    HStack(spacing: .layer1) {
+                        Text(model.community.title)
+                            .font(showCounts ? .headline.bold() : .footnote.bold())
+                            .lineLimit(1)
+                            .cornerRadius(4)
+                        
+                        Spacer()
+                    }//.scrollOnOverflow()
+                    
+                    Group {
+                        HStack(spacing: .layer1) {
+                            Text("!"+model.community.name)
+                                .font(.subheadline)
+                                .cornerRadius(4)
+                            Text("\(peerHost ?? "")@" + model.community.actor_id.host)
+                                .font(.caption2)
+                                .lineLimit(1)
+                                .padding(.vertical, .layer1)
+                                .padding(.horizontal, .layer1)
+                                .background(Color.tertiaryBackground)
+                                .cornerRadius(4)
+                        }
+                        
+                        Spacer()
+                    }
                 }
+                .offset(y: .layer1)
                 .onTapGesture {
                     routeCommunityView()
                 }
@@ -208,9 +206,9 @@ struct CommunityCardView: View {
             }
             .padding(.layer3)
             .foregroundColor(.foreground)
+            .frame(maxWidth: fullWidth ? .infinity : ContainerConfig.iPhoneScreenWidth * 0.9, maxHeight: 88)
             .background(Color.secondaryBackground)
             .cornerRadius(8)
-            .frame(maxWidth: fullWidth ? .infinity : ContainerConfig.iPhoneScreenWidth * 0.9, maxHeight: 88)
             .outlineIf(outline)
             
             if showCounts {

--- a/Shared/LAViews/Posts/PostDisplayView/PostDisplayView.swift
+++ b/Shared/LAViews/Posts/PostDisplayView/PostDisplayView.swift
@@ -123,7 +123,8 @@ struct PostDisplayView: GraniteNavigationDestination {
     
     //This inserts into a HStack
     var destinationStyle: GraniteNavigationDestinationStyle {
-        return .customTrailing(fullWidth: Device.isExpandedLayout,
+        return .customTrailing(Color.background,
+                               fullWidth: Device.isExpandedLayout,
                                hideLeadingView: Device.isExpandedLayout)
     }
 }

--- a/Shared/Utility/Device.swift
+++ b/Shared/Utility/Device.swift
@@ -55,7 +55,7 @@ struct Device {
             return false
         }
         
-        if UIDevice.current.orientation.isPortrait {
+        if UIDevice.current.orientation.isPortrait || windowScene.interfaceOrientation.isPortrait  {
             return keyWindow.safeAreaInsets.bottom > 0
         } else {
             return keyWindow.safeAreaInsets.left > 0 || keyWindow.safeAreaInsets.right > 0

--- a/Shared/Utility/Device.swift
+++ b/Shared/Utility/Device.swift
@@ -74,6 +74,22 @@ struct Device {
             return nil
         }
     }
+    
+    static var statusBarHeight:  CGFloat {
+        #if os(iOS)
+        guard let windowScene = UIApplication.shared
+            .connectedScenes
+            .first as? UIWindowScene else {
+            LoomLog("Could not get connected scene", level: .error)
+            return 0
+        }
+        
+        return windowScene.statusBarManager?.statusBarFrame.height ?? 0
+        
+        #else
+        return 0
+        #endif
+    }
 }
 
 extension Bundle {

--- a/Shared/Utility/Pager/Pager.LoadingView.swift
+++ b/Shared/Utility/Pager/Pager.LoadingView.swift
@@ -28,6 +28,15 @@ struct PagerFooterLoadingView<Model: Pageable>: View {
     
     @State var progress: CGFloat = 0.0
     
+    //ideally the same height as the tab bar
+    var height: CGFloat {
+        if Device.hasNotch {
+            return 75
+        } else {
+            return 60
+        }
+    }
+    
     var body: some View {
         
         VStack {
@@ -47,7 +56,7 @@ struct PagerFooterLoadingView<Model: Pageable>: View {
                     }
             }
         }
-        .frame(maxWidth: .infinity, minHeight: 60, maxHeight: 60)
+        .frame(maxWidth: .infinity, minHeight: height, maxHeight: height)
         .overlay(
             GeometryReader { proxy in
                 ZStack {

--- a/Shared/Utility/Pager/Pager.ScrollView.HidingHeader.swift
+++ b/Shared/Utility/Pager/Pager.ScrollView.HidingHeader.swift
@@ -1,0 +1,48 @@
+//
+//  Pager.ScrollView.HidingHeader.swift
+//  Loom
+//
+//  Created by Ritesh Pakala on 8/29/23.
+//
+
+import Foundation
+import SwiftUI
+import Granite
+import GraniteUI
+
+extension PagerScrollView {
+    //Does not take addContent
+    var hidingHeaderScrollView: some View {
+        GraniteScrollView(showsIndicators: false,
+                          onRefresh: pager.refresh(_:),
+                          hidingHeader: properties.hidingHeader,
+                          bgColor: properties.backgroundColor,
+                          header: header) {
+            if properties.lazy {
+                LazyVStack(spacing: 0) {
+                    ForEach(currentItems) { item in
+                        if properties.cacheViews {
+                            cache(item)
+                                .environment(\.pagerMetadata, pager.itemMetadatas[item.id])
+                        } else {
+                            mainContent(item)
+                                .environment(\.pagerMetadata, pager.itemMetadatas[item.id])
+                        }
+                    }
+                }
+            } else {
+                VStack(spacing: 0) {
+                    ForEach(currentItems) { item in
+                        mainContent(item)
+                            .environment(\.pagerMetadata, pager.itemMetadatas[item.id])
+                    }
+                }
+            }
+            
+            if properties.showFetchMore {
+                PagerFooterLoadingView<Model>()
+                    .environmentObject(pager)
+            }
+        }
+    }
+}

--- a/Shared/Utility/Pager/Pager.ScrollView.swift
+++ b/Shared/Utility/Pager/Pager.ScrollView.swift
@@ -63,7 +63,6 @@ struct PagerScrollView<Model: Pageable, Header: View, AddContent: View, Content:
                         .padding(.top, 0)
                 }
                 header()
-                    .scrollOnOverflow(axis: .vertical)
                 VStack(spacing: 0) {
                     if !properties.alternateContentPosition {
                         addContent()

--- a/Shared/Utility/Pager/Pager.ScrollView.swift
+++ b/Shared/Utility/Pager/Pager.ScrollView.swift
@@ -20,6 +20,7 @@ struct PagerScrollView<Model: Pageable, Header: View, AddContent: View, Content:
         var hideLastDivider: Bool = false
         var performant: Bool = false
         var partition: Bool = false
+        var hidingHeader: Bool = false
         var lazy: Bool = true
         var cacheViews: Bool = false
         var listView: Bool = false
@@ -62,6 +63,7 @@ struct PagerScrollView<Model: Pageable, Header: View, AddContent: View, Content:
                         .padding(.top, 0)
                 }
                 header()
+                    .scrollOnOverflow(axis: .vertical)
                 VStack(spacing: 0) {
                     if !properties.alternateContentPosition {
                         addContent()
@@ -71,7 +73,7 @@ struct PagerScrollView<Model: Pageable, Header: View, AddContent: View, Content:
                         .frame(maxHeight: .infinity)
                 }
             } else {
-                if properties.performant {
+                if properties.performant && properties.hidingHeader == false {
                     if Device.isExpandedLayout == false {
                         header()
                     }
@@ -80,6 +82,8 @@ struct PagerScrollView<Model: Pageable, Header: View, AddContent: View, Content:
                     partitionScrollView
                 } else if Device.isMacOS == false && properties.listView {
                     listView
+                } else if properties.hidingHeader {
+                    hidingHeaderScrollView
                 } else {
                     normalScrollView
                 }

--- a/Shared/Views/GraniteScrollView/GraniteScrollView+Proxy.swift
+++ b/Shared/Views/GraniteScrollView/GraniteScrollView+Proxy.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+struct ScrollViewOffsetPreferenceKey: PreferenceKey {
+    static var defaultValue: CGPoint = .zero
+    
+    static func reduce(value: inout CGPoint, nextValue: () -> CGPoint) {
+        value = nextValue()
+    }
+    
+    typealias Value = CGPoint
+
+}
+
+struct ScrollViewOffsetModifier: ViewModifier {
+    let coordinateSpace: String
+    @Binding var offset: CGPoint
+    
+    func body(content: Content) -> some View {
+        ZStack {
+            content
+            GeometryReader { proxy in
+                let x = proxy.frame(in: .named(coordinateSpace)).minX
+                let y = proxy.frame(in: .named(coordinateSpace)).minY
+                Color.clear.preference(key: ScrollViewOffsetPreferenceKey.self, value: CGPoint(x: x * -1, y: y * -1))
+            }
+        }
+        .onPreferenceChange(ScrollViewOffsetPreferenceKey.self) { value in
+            offset = value
+        }
+    }
+}
+
+extension View {
+    func readingScrollViewIf(_ condition: Bool, from coordinateSpace: String, into binding: Binding<CGPoint>) -> some View {
+        Group {
+            if condition {
+                self.modifier(ScrollViewOffsetModifier(coordinateSpace: coordinateSpace, offset: binding))
+            } else {
+                self
+            }
+        }
+    }
+    func readingScrollView(from coordinateSpace: String, into binding: Binding<CGPoint>) -> some View {
+        modifier(ScrollViewOffsetModifier(coordinateSpace: coordinateSpace, offset: binding))
+    }
+}

--- a/Shared/Views/GraniteScrollView/GraniteScrollView.swift
+++ b/Shared/Views/GraniteScrollView/GraniteScrollView.swift
@@ -200,15 +200,15 @@ public struct GraniteScrollView<Content : View, ContentHeader : View> : View {
     public var body: some View {
         ScrollView(axes, showsIndicators: showsIndicators) {
             VStack(spacing: 0) {
+                GraniteScrollViewPositionIndicator(type: .moving)
+                    .frame(height: 0)
+                    .background(
+                        Reader(startDraggingOffset: $startDraggingOffset,
+                               onReachedEdge: onReachedEdge)
+                    )
+                
                 if hidingHeader {
                     header()
-                } else {
-                    GraniteScrollViewPositionIndicator(type: .moving)
-                        .frame(height: 0)
-                        .background(
-                            Reader(startDraggingOffset: $startDraggingOffset,
-                                   onReachedEdge: onReachedEdge)
-                        )
                 }
                 
                 if status != .idle {

--- a/Shared/Views/GraniteScrollView/GraniteScrollView.swift
+++ b/Shared/Views/GraniteScrollView/GraniteScrollView.swift
@@ -57,12 +57,15 @@ public struct GraniteScrollView<Content : View, ContentHeader : View> : View {
             didSet {
                 if initialOffset == nil {
                     initialOffset = offset
+                    update()
                 }
                 
-                if offset.y >= 0 {
+                if offset.y >= 0 && isResting {
                     isResting = false
-                } else if offset.y <= initialOffset?.y ?? 0 {
+                    update()
+                } else if offset.y <= initialOffset?.y ?? 0 && !isResting {
                     isResting =  true
+                    update()
                 }
                 
                 let lastDirection = direction
@@ -222,6 +225,7 @@ public struct GraniteScrollView<Content : View, ContentHeader : View> : View {
                         content
                             .frame(maxHeight: .infinity)
                     }
+                    
                 }
                 .readingScrollViewIf(hidingHeader,
                                      from: "granite.scrollview",
@@ -233,16 +237,22 @@ public struct GraniteScrollView<Content : View, ContentHeader : View> : View {
             }
         }
         .coordinateSpace(name: "granite.scrollview")
-        .overlayIf(hidingHeader) {
+        .overlayIf(hidingHeader, alignment: .top) {
             VStack(spacing: 0) {
-                if directionBox.isResting == false {
+                //if directionBox.isResting == false {
                     header()
-                        .offset(y: directionBox.accessoryOffsetY)
+                        //.offset(y: directionBox.accessoryOffsetY)
                         .opacity(directionBox.isShowingAccessory ? 1.0 : 0.0)
-                        .animation(directionBox.isShowingAccessory ? .linear(duration: 0.6) : .easeOut(duration: 0.7), value: directionBox.isShowingAccessory)
-                }
-
+                //}
+                
                 Spacer()
+            }
+            .animation(directionBox.isResting ? nil : (directionBox.isShowingAccessory ? .linear(duration: 0.6) : .easeOut(duration: 0.7)), value: directionBox.isShowingAccessory)
+            .overlay(alignment: .top) {
+                Rectangle()
+                    .frame(height: Device.statusBarHeight)
+                    .foregroundColor(bgColor.opacity(0.6))
+
             }
         }
         .background(GraniteScrollViewPositionIndicator(type: .fixed))

--- a/Shared/Views/GraniteScrollView/GraniteScrollView.swift
+++ b/Shared/Views/GraniteScrollView/GraniteScrollView.swift
@@ -8,7 +8,7 @@ import Foundation
 
 // Heavily influenced and adopted from
 // https://github.com/globulus/swiftui-pull-to-refresh/blob/main/Sources/SwiftUIPullToRefresh/SwiftUIPullToRefresh.swift
-public struct GraniteScrollView<Content : View> : View {
+public struct GraniteScrollView<Content : View, ContentHeader : View> : View {
    
     private enum Status {
         case idle
@@ -20,6 +20,102 @@ public struct GraniteScrollView<Content : View> : View {
     public enum Edge {
         case top
         case bottom
+    }
+    
+    enum Direction: Equatable {
+        case up(CGFloat)
+        case down(CGFloat)
+        
+        var value: CGFloat {
+            switch self {
+            case .up(let y), .down(let y):
+                return y
+            }
+        }
+        
+        var label: String {
+            switch self {
+            case .down:
+                return "down"
+            case .up:
+                return "up"
+            }
+        }
+        
+        var isUp: Bool {
+            switch self {
+            case .up:
+                return true
+            default:
+                return false
+            }
+        }
+    }
+    
+    public class DirectionBox: ObservableObject {
+        var offset: CGPoint = .zero {
+            didSet {
+                if initialOffset == nil {
+                    initialOffset = offset
+                }
+                
+                if offset.y >= 0 {
+                    isResting = false
+                } else if offset.y <= initialOffset?.y ?? 0 {
+                    isResting =  true
+                }
+                
+                let lastDirection = direction
+                if offset.y > oldValue.y {
+                    direction = .down(offset.y)
+                } else {
+                    direction = .up(offset.y)
+                }
+                
+                if direction.label != lastDirection.label {
+                    directionChangedAt = lastDirection
+                }
+                
+                let triggerArea: Bool = offset.y > abs(initialOffset?.y ?? 0) + 120
+                if isResting && isShowingAccessory {
+                    isShowingAccessory = false
+                    update()
+                } else if distance > 120 && direction.isUp != isShowingAccessory && triggerArea {
+                    isShowingAccessory = direction.isUp
+                    update()
+                }
+            }
+        }
+        
+        var initialOffset: CGPoint? = nil
+        
+        var directionChangedAt: Direction = .down(0)
+        var direction: Direction = .down(0)
+        
+        var distance: CGFloat {
+            guard directionChangedAt.label != direction.label else {
+                return 0
+            }
+            return abs(direction.value - directionChangedAt.value)
+        }
+        
+        var accessoryOffsetY: CGFloat {
+            let safeAreaTop = UIApplication.shared.windowSafeAreaInsets.top
+            
+            if isShowingAccessory {
+                return 0
+            } else {
+                return (initialOffset?.y ?? 0) + (-safeAreaTop)
+            }
+        }
+        var isResting: Bool = true
+        var isShowingAccessory: Bool = false
+        
+        func update() {
+            DispatchQueue.main.async {
+                self.objectWillChange.send()
+            }
+        }
     }
     
     public typealias ReachedEdgeHandler = (Edge) -> Void
@@ -34,6 +130,7 @@ public struct GraniteScrollView<Content : View> : View {
     private let onRefresh : RefreshHandler?
     private let onFetchMore : FetchMoreHandler?
     private let onReachedEdge : ReachedEdgeHandler?
+    private let header : () -> ContentHeader
     private let content : Content
     
     @State private var status : Status = .idle
@@ -41,6 +138,9 @@ public struct GraniteScrollView<Content : View> : View {
     @State private var progress : Double = 0
     @State private var fetchMoreProgress : Double = 0
     @State private var startDraggingOffset : CGPoint = .zero
+    @ObservedObject private var directionBox: DirectionBox = .init()
+    
+    private var hidingHeader: Bool
     
     private let bgColor: Color
     
@@ -49,7 +149,9 @@ public struct GraniteScrollView<Content : View> : View {
                 onRefresh : RefreshHandler? = nil,
                 onFetchMore : FetchMoreHandler? = nil,
                 onReachedEdge : ReachedEdgeHandler? = nil,
+                hidingHeader : Bool = false,
                 bgColor: Color = .clear,
+                @ViewBuilder header: @escaping () -> ContentHeader = { EmptyView() },
                 @ViewBuilder content: () -> Content) {
         self.axes = axes
         self.showsIndicators = showsIndicators
@@ -57,6 +159,8 @@ public struct GraniteScrollView<Content : View> : View {
         self.onFetchMore = onFetchMore
         self.onReachedEdge = onReachedEdge
         self.bgColor = bgColor
+        self.header = header
+        self.hidingHeader = hidingHeader
         self.content = content()
     }
     
@@ -93,21 +197,52 @@ public struct GraniteScrollView<Content : View> : View {
     public var body: some View {
         ScrollView(axes, showsIndicators: showsIndicators) {
             VStack(spacing: 0) {
-                GraniteScrollViewPositionIndicator(type: .moving)
-                    .frame(height: 0)
-                    .overlay(
-                        Reader(startDraggingOffset: $startDraggingOffset,
-                               onReachedEdge: onReachedEdge)
-                    )
+                if hidingHeader {
+                    header()
+                } else {
+                    GraniteScrollViewPositionIndicator(type: .moving)
+                        .frame(height: 0)
+                        .background(
+                            Reader(startDraggingOffset: $startDraggingOffset,
+                                   onReachedEdge: onReachedEdge)
+                        )
+                }
                 
                 if status != .idle {
                     Color.clear
                         .frame(height: status == .loading ? style.threshold : style.threshold * CGFloat(progress))
                 }
                 
-                content
-                    .frame(maxHeight: .infinity)
-                    .overlay(onRefresh != nil ? progressBody : nil, alignment: .top)
+                ZStack(alignment: .top) {
+                    if onRefresh != nil {
+                        progressBody
+                    }
+                    
+                    VStack(spacing: 0) {
+                        content
+                            .frame(maxHeight: .infinity)
+                    }
+                }
+                .readingScrollViewIf(hidingHeader,
+                                     from: "granite.scrollview",
+                                     into: .init(get: {
+                    return directionBox.offset
+                }, set: { value in
+                    directionBox.offset = value
+                }))
+            }
+        }
+        .coordinateSpace(name: "granite.scrollview")
+        .overlayIf(hidingHeader) {
+            VStack(spacing: 0) {
+                if directionBox.isResting == false {
+                    header()
+                        .offset(y: directionBox.accessoryOffsetY)
+                        .opacity(directionBox.isShowingAccessory ? 1.0 : 0.0)
+                        .animation(directionBox.isShowingAccessory ? .linear(duration: 0.6) : .easeOut(duration: 0.7), value: directionBox.isShowingAccessory)
+                }
+
+                Spacer()
             }
         }
         .background(GraniteScrollViewPositionIndicator(type: .fixed))

--- a/Shared/Views/LinkPreview/LinkPreviewDesign.swift
+++ b/Shared/Views/LinkPreview/LinkPreviewDesign.swift
@@ -11,6 +11,11 @@ import Granite
 import UniformTypeIdentifiers
 import ModerationKit
 
+/*
+ TODO: cleanup and remove LinkPreview and related files in favor of
+       ContentMetadataView
+ */
+
 struct LinkPreviewDesign: View {
     
     let metaData: LPLinkMetadata
@@ -231,10 +236,12 @@ struct LinkPreviewDesign: View {
                                 .padding(.all, 8)
                         }
                     } else {
-                        Image(uiImage: img)
-                            .resizable()
-                            .aspectRatio(contentMode: .fill)
-                            .clipped()
+                        ScrollView(showsIndicators: false) {
+                            Image(uiImage: img)
+                                .resizable()
+                                .aspectRatio(contentMode: .fill)
+                                .clipped()
+                        }
                         
                         if let icon = cachedIcon {
                             Image(uiImage: icon)
@@ -264,10 +271,12 @@ struct LinkPreviewDesign: View {
                                 .padding(.all, 8)
                         }
                     } else {
-                        Image(nsImage: img)
-                            .resizable()
-                            .aspectRatio(contentMode: .fill)
-                            .clipped()
+                        ScrollView(showsIndicators: false) {
+                            Image(nsImage: img)
+                                .resizable()
+                                .aspectRatio(contentMode: .fill)
+                                .clipped()
+                        }
                         
                         if let icon = cachedIcon {
                             Image(nsImage: icon)


### PR DESCRIPTION
Features:
- hide headerview of feed on mobile while scrolling

Bugs:
- config/accounts restore on fresh launch. Still 1 known edge case where it may not, still investigating.
- Inside a Post view header duplicates on expanded macOS/iPad layouts 
- communitycard views (in search) we're slightly cutoff on the topleft/topright rounded corners 
- the community cards tapped on mobile, inside the second tab was not routing
- inside the post, long thumbnails would not overflow
- iPhone 14, tab bar padding adjusted

Note: iPad/macOS updates to catch up to iPhone will take place later this week.